### PR TITLE
Small improvements to public documentation

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -42,7 +42,7 @@ impl Error {
     /// extern crate vmm_sys_util;
     /// #
     /// # use libc;
-    /// use vmm_sys_util::Error;
+    /// use vmm_sys_util::errno::Error;
     ///
     /// let err = Error::new(libc::EBADFD);
     /// ```
@@ -67,7 +67,7 @@ impl Error {
     /// # use std::fs::File;
     /// # use std::io::{self, Write};
     /// # use std::os::unix::io::FromRawFd;
-    /// use vmm_sys_util::Error;
+    /// use vmm_sys_util::errno::Error;
     /// #
     /// // Writing to an invalid file returns the error number EBADF.
     /// let mut file = unsafe { File::from_raw_fd(-1) };
@@ -86,7 +86,7 @@ impl Error {
     /// # Examples
     /// ```
     /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::Error;
+    /// use vmm_sys_util::errno::Error;
     ///
     /// let err = Error::new(13);
     /// assert_eq!(err.errno(), 13);

--- a/src/fallocate.rs
+++ b/src/fallocate.rs
@@ -1,0 +1,47 @@
+use std::os::unix::io::AsRawFd;
+
+use crate::errno::{errno_result, Error, Result};
+
+pub enum FallocateMode {
+    PunchHole,
+    ZeroRange,
+}
+
+/// Safe wrapper for `fallocate()`.
+pub fn fallocate(
+    file: &dyn AsRawFd,
+    mode: FallocateMode,
+    keep_size: bool,
+    offset: u64,
+    len: u64,
+) -> Result<()> {
+    let offset = if offset > libc::off64_t::max_value() as u64 {
+        return Err(Error::new(libc::EINVAL));
+    } else {
+        offset as libc::off64_t
+    };
+
+    let len = if len > libc::off64_t::max_value() as u64 {
+        return Err(Error::new(libc::EINVAL));
+    } else {
+        len as libc::off64_t
+    };
+
+    let mut mode = match mode {
+        FallocateMode::PunchHole => libc::FALLOC_FL_PUNCH_HOLE,
+        FallocateMode::ZeroRange => libc::FALLOC_FL_ZERO_RANGE,
+    };
+
+    if keep_size {
+        mode |= libc::FALLOC_FL_KEEP_SIZE;
+    }
+
+    // Safe since we pass in a valid fd and fallocate mode, validate offset and len,
+    // and check the return value.
+    let ret = unsafe { libc::fallocate64(file.as_raw_fd(), mode, offset, len) };
+    if ret < 0 {
+        errno_result()
+    } else {
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,80 +1,23 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 extern crate libc;
 
-mod tempdir;
+// Export the syslog module first so that the macros are available to the other modules.
+#[macro_use]
+pub mod syslog;
 
 #[macro_use]
 pub mod ioctl;
-
 /// Structures, helpers, and type definitions for working with
 /// [`errno`](http://man7.org/linux/man-pages/man3/errno.3.html).
 pub mod errno;
 pub mod eventfd;
+pub mod fallocate;
 pub mod file_traits;
+pub mod poll;
 pub mod seek_hole;
 pub mod signal;
+pub mod tempdir;
 pub mod terminal;
 pub mod timerfd;
 pub mod write_zeroes;
-
-#[macro_use]
-pub mod syslog;
-
-pub mod poll;
-
-pub use crate::tempdir::*;
-pub use errno::*;
-pub use eventfd::*;
-pub use poll::*;
-
-use std::os::unix::io::AsRawFd;
-
-pub use crate::file_traits::{FileSetLen, FileSync};
-pub use crate::seek_hole::SeekHole;
-pub use crate::write_zeroes::{PunchHole, WriteZeroes};
-
-pub enum FallocateMode {
-    PunchHole,
-    ZeroRange,
-}
-
-/// Safe wrapper for `fallocate()`.
-pub fn fallocate(
-    file: &dyn AsRawFd,
-    mode: FallocateMode,
-    keep_size: bool,
-    offset: u64,
-    len: u64,
-) -> Result<()> {
-    let offset = if offset > libc::off64_t::max_value() as u64 {
-        return Err(Error::new(libc::EINVAL));
-    } else {
-        offset as libc::off64_t
-    };
-
-    let len = if len > libc::off64_t::max_value() as u64 {
-        return Err(Error::new(libc::EINVAL));
-    } else {
-        len as libc::off64_t
-    };
-
-    let mut mode = match mode {
-        FallocateMode::PunchHole => libc::FALLOC_FL_PUNCH_HOLE,
-        FallocateMode::ZeroRange => libc::FALLOC_FL_ZERO_RANGE,
-    };
-
-    if keep_size {
-        mode |= libc::FALLOC_FL_KEEP_SIZE;
-    }
-
-    // Safe since we pass in a valid fd and fallocate mode, validate offset and len,
-    // and check the return value.
-    let ret = unsafe { libc::fallocate64(file.as_raw_fd(), mode, offset, len) };
-    if ret < 0 {
-        errno_result()
-    } else {
-        Ok(())
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ mod tempdir;
 #[macro_use]
 pub mod ioctl;
 
+/// Structures, helpers, and type definitions for working with
+/// [`errno`](http://man7.org/linux/man-pages/man3/errno.3.html).
 pub mod errno;
 pub mod eventfd;
 pub mod file_traits;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -22,7 +22,7 @@ use libc::{
     EPOLL_CLOEXEC, EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD,
 };
 
-use crate::{errno_result, Error, Result};
+use crate::errno::{errno_result, Error, Result};
 
 macro_rules! handle_eintr_errno {
     ($x:expr) => {{
@@ -463,8 +463,10 @@ impl<T: PollToken> IntoRawFd for EpollContext<T> {
 /// # Example
 ///
 /// ```
-/// # use vmm_sys_util::{Result, EventFd, PollContext, PollEvents};
-/// # fn test() -> Result<()> {
+/// # use vmm_sys_util::errno::Result;
+/// # use vmm_sys_util::eventfd::EventFd;
+/// # use vmm_sys_util::poll::{PollContext, PollEvents};
+/// fn test() -> Result<()> {
 ///     let evt1 = EventFd::new(0)?;
 ///     let evt2 = EventFd::new(0)?;
 ///     evt2.write(1)?;
@@ -476,8 +478,8 @@ impl<T: PollToken> IntoRawFd for EpollContext<T> {
 ///     let pollevents: PollEvents<u32> = ctx.wait()?;
 ///     let tokens: Vec<u32> = pollevents.iter_readable().map(|e| e.token()).collect();
 ///     assert_eq!(&tokens[..], &[2]);
-/// #   Ok(())
-/// # }
+///   Ok(())
+/// }
 /// ```
 pub struct PollContext<T> {
     epoll_ctx: EpollContext<T>,

--- a/src/seek_hole.rs
+++ b/src/seek_hole.rs
@@ -65,7 +65,7 @@ impl SeekHole for File {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TempDir;
+    use crate::tempdir::TempDir;
     use std::fs::File;
     use std::io::{Seek, SeekFrom, Write};
     use std::path::PathBuf;

--- a/src/tempdir.rs
+++ b/src/tempdir.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 
 use libc;
 
-use crate::{errno_result, Result};
+use crate::errno::{errno_result, Result};
 
 /// Create and remove a temporary directory.  The directory will be maintained for the lifetime of
 /// the `TempDir` object.
@@ -31,7 +31,7 @@ impl TempDir {
     /// ```
     /// # use std::path::Path;
     /// # use std::path::PathBuf;
-    /// # use vmm_sys_util::TempDir;
+    /// # use vmm_sys_util::tempdir::TempDir;
     /// # fn test_create_temp_dir() -> Result<(), ()> {
     ///       let t = TempDir::new("/tmp/testdir").map_err(|_| ())?;
     ///       assert!(t.as_path().unwrap().exists());

--- a/src/write_zeroes.rs
+++ b/src/write_zeroes.rs
@@ -8,8 +8,7 @@ use std::cmp::min;
 use std::fs::File;
 use std::io::{self, Seek, SeekFrom, Write};
 
-use crate::fallocate;
-use crate::FallocateMode;
+use crate::fallocate::{fallocate, FallocateMode};
 
 /// A trait for deallocating space in a file.
 pub trait PunchHole {
@@ -64,7 +63,7 @@ mod tests {
     use std::io::{Read, Seek, SeekFrom};
     use std::path::PathBuf;
 
-    use crate::TempDir;
+    use crate::tempdir::TempDir;
 
     #[test]
     fn simple_test() {


### PR DESCRIPTION
I only updated the documentation for the errno module by adding some more details to existing docs and  examples.
I also did a bit of cleanup in the way we are exporting functionality from this crate. The major change is having all functionality exported in public modules as oppose to export some of the functionality as bulk using `pub use mod_name::*`. This change also improves the readability of the documentation. Check it out with ```cargo doc --open```.