### PR TITLE
seek_hole: Fix clippy lint (cyclomatic_complexity)

### DIFF
--- a/src/seek_hole.rs
+++ b/src/seek_hole.rs
@@ -122,7 +122,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     fn seek_hole() {
         let tempdir = TempDir::new("/tmp/seek_hole_test").unwrap();
         let mut path = PathBuf::from(tempdir.as_path().unwrap());


### PR DESCRIPTION
Seems that `clippy::cyclomatic_complexity` has been renamed to `clippy::cognitive_complexity`.

This tiny PR updates that in the code.