### PR TITLE
license: improvements on license

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1,12 +1,10 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 use std::fmt::{Display, Formatter};
 use std::io;

--- a/src/eventfd.rs
+++ b/src/eventfd.rs
@@ -1,9 +1,8 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Copyright 2017 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 //! Structure and wrapper functions for working with
 //! [`eventfd`](http://man7.org/linux/man-pages/man2/eventfd.2.html).

--- a/src/fallocate.rs
+++ b/src/fallocate.rs
@@ -1,3 +1,9 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
 //! Enum and function for dealing with an allocated disk space
 //! by [`fallocate`](http://man7.org/linux/man-pages/man2/fallocate.2.html).
 

--- a/src/file_traits.rs
+++ b/src/file_traits.rs
@@ -1,8 +1,8 @@
-// Copyright 2018 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+// Copyright 2019 Intel Corporation. All Rights Reserved.
 //
-// SPDX-License-Identifier: BSD-3-Clause
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 //! Traits for handling file synchronization and length.
 

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -1,12 +1,10 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 //! Macros and functions for working with
 //! [`ioctl`](http://man7.org/linux/man-pages/man2/ioctl.2.html).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 extern crate libc;
 
 // Export the syslog module first so that the macros are available to the other modules.

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,9 +1,8 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Copyright 2017 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 use std::cell::{Cell, Ref, RefCell};
 use std::cmp::min;

--- a/src/seek_hole.rs
+++ b/src/seek_hole.rs
@@ -1,8 +1,8 @@
-// Copyright 2018 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+// Copyright 2019 Intel Corporation. All Rights Reserved.
 //
-// SPDX-License-Identifier: BSD-3-Clause
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 use std::fs::File;
 use std::io::{Error, Result};

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,12 +1,10 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
-// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 use libc::{
     c_int, c_void, pthread_kill, pthread_sigmask, pthread_t, sigaction, sigaddset, sigemptyset,

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -1,9 +1,8 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Copyright 2017 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 //! Facilities for sending log message to syslog.
 //!

--- a/src/tempdir.rs
+++ b/src/tempdir.rs
@@ -1,8 +1,8 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+// Copyright 2019 Intel Corporation. All Rights Reserved.
 //
-// SPDX-License-Identifier: BSD-3-Clause
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 use std::ffi::CString;
 use std::ffi::OsStr;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,12 +1,10 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Copyright 2017 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 //! Trait for working with [`termios`](http://man7.org/linux/man-pages/man3/termios.3.html).
 

--- a/src/timerfd.rs
+++ b/src/timerfd.rs
@@ -1,9 +1,8 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
 //
 // Copyright 2018 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-clause file.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 //! Structure and functions for working with
 //! [`timerfd`](http://man7.org/linux/man-pages/man2/timerfd_create.2.html).

--- a/src/write_zeroes.rs
+++ b/src/write_zeroes.rs
@@ -1,8 +1,8 @@
-// Copyright 2018 The Chromium OS Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE-BSD-3-Clause file.
+// Copyright 2019 Intel Corporation. All Rights Reserved.
 //
-// SPDX-License-Identifier: BSD-3-Clause
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
 //! Traits for replacing a range with a hole and writing zeroes in a file.
 


### PR DESCRIPTION
The crate needs Apache-2.0 or BSD-3-Clause but some files are not correctly
described with the license. Make all files correct on license declaration.
