### PR TITLE
Tempdir Documentation & Refactoring

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 74.3,
+  "coverage_score": 74.2,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/fallocate.rs
+++ b/src/fallocate.rs
@@ -44,7 +44,7 @@ pub enum FallocateMode {
 /// use vmm_sys_util::tempdir::TempDir;
 ///
 /// let tempdir = TempDir::new("/tmp/fallocate_test").unwrap();
-/// let mut path = PathBuf::from(tempdir.as_path().unwrap());
+/// let mut path = PathBuf::from(tempdir.as_path());
 /// path.push("file");
 /// let mut f = OpenOptions::new()
 ///     .read(true)

--- a/src/file_traits.rs
+++ b/src/file_traits.rs
@@ -60,7 +60,7 @@ mod tests {
     #[test]
     fn test_fsync() {
         let tempdir = TempDir::new("/tmp/fsync_test").unwrap();
-        let mut path = PathBuf::from(tempdir.as_path().unwrap());
+        let mut path = PathBuf::from(tempdir.as_path());
         path.push("file");
         let mut f = OpenOptions::new()
             .read(true)
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn test_set_len() {
         let tempdir = TempDir::new("/tmp/set_len_test").unwrap();
-        let mut path = PathBuf::from(tempdir.as_path().unwrap());
+        let mut path = PathBuf::from(tempdir.as_path());
         path.push("file");
         let mut f = OpenOptions::new()
             .read(true)

--- a/src/seek_hole.rs
+++ b/src/seek_hole.rs
@@ -77,7 +77,7 @@ mod tests {
     #[test]
     fn seek_data() {
         let tempdir = TempDir::new("/tmp/seek_data_test").unwrap();
-        let mut path = PathBuf::from(tempdir.as_path().unwrap());
+        let mut path = PathBuf::from(tempdir.as_path());
         path.push("test_file");
         let mut file = File::create(&path).unwrap();
 
@@ -125,7 +125,7 @@ mod tests {
     #[allow(clippy::cognitive_complexity)]
     fn seek_hole() {
         let tempdir = TempDir::new("/tmp/seek_hole_test").unwrap();
-        let mut path = PathBuf::from(tempdir.as_path().unwrap());
+        let mut path = PathBuf::from(tempdir.as_path());
         path.push("test_file");
         let mut file = File::create(&path).unwrap();
 

--- a/src/write_zeroes.rs
+++ b/src/write_zeroes.rs
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn simple_test() {
         let tempdir = TempDir::new("/tmp/write_zeroes_test").unwrap();
-        let mut path = PathBuf::from(tempdir.as_path().unwrap());
+        let mut path = PathBuf::from(tempdir.as_path());
         path.push("file");
         let mut f = OpenOptions::new()
             .read(true)
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn large_write_zeroes() {
         let tempdir = TempDir::new("/tmp/write_zeroes_test").unwrap();
-        let mut path = PathBuf::from(tempdir.as_path().unwrap());
+        let mut path = PathBuf::from(tempdir.as_path());
         path.push("file");
         let mut f = OpenOptions::new()
             .read(true)


### PR DESCRIPTION
- added missing documentation
- refactored existing documentation examples so that we don't use functions
- the path field is now not optional anymore as there was no good reason for it to be optional