### PR TITLE
errno: moved module documentation to module file

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -6,6 +6,9 @@
 //
 // SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 
+//! Structures, helpers, and type definitions for working with
+//! [`errno`](http://man7.org/linux/man-pages/man3/errno.3.html).
+
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,6 @@ pub mod syslog;
 
 #[macro_use]
 pub mod ioctl;
-/// Structures, helpers, and type definitions for working with
-/// [`errno`](http://man7.org/linux/man-pages/man3/errno.3.html).
 pub mod errno;
 pub mod eventfd;
 pub mod fallocate;


### PR DESCRIPTION
Moved errno documentation from src/lib.rs to errno module.