### PR TITLE
Implement from/into_raw() for FamStructWrapper

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 83.7,
+  "coverage_score": 83.9,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
This rework `commit 27e7ff14d60de7ab22dbfbd46464798fa0714294 Implement From<Vec<T>> for FamStructWrapper<T>` with better abstraction.