### PR TITLE
CHANGELOG: Add the aio and sock_ctr_msg modules to the 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Firecracker projects, or both.
 
 The first release comes with the following Rust modules:
 
+* aio: Safe wrapper over [`Linux AIO`](http://man7.org/linux/man-pages/man7/aio.7.html).
+
 * errno: Structures, helpers, and type definitions for working with
   [`errno`](http://man7.org/linux/man-pages/man3/errno.3.html).
 
@@ -36,6 +38,9 @@ The first release comes with the following Rust modules:
 
 * signal: Enums, traits and functions for working with
   [`signal`](http://man7.org/linux/man-pages/man7/signal.7.html).
+
+* sockctrl_msg: Wrapper for sending and receiving messages with file descriptors
+  on sockets that accept control messages (e.g. Unix domain sockets).
 
 * tempdir: Structure for handling temporary directories.
 


### PR DESCRIPTION
I missed those when building the first version.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>