### PR TITLE
CHANGELOG: v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.1
+
+* Fixed the Cargo.toml license.
+* Fixed some clippy warnings
+
 # v0.1.0
 
 This is the first vmm-sys-util crate release.


### PR DESCRIPTION
Mostly for having a clean crates.io package license.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>