### PR TITLE
fam: macro to impl FamStruct also takes entries field name

### DIFF
--- a/src/fam.rs
+++ b/src/fam.rs
@@ -429,7 +429,8 @@ impl<T: Default + FamStruct + Clone> From<Vec<T>> for FamStructWrapper<T> {
 /// Generate `FamStruct` implementation for structs with flexible array member.
 #[macro_export]
 macro_rules! generate_fam_struct_impl {
-    ($struct_type: ty, $entry_type: ty, $field_type: ty, $field_name: ident, $max: expr) => {
+    ($struct_type: ty, $entry_type: ty, $entries_name: ident,
+     $field_type: ty, $field_name: ident, $max: expr) => {
         unsafe impl FamStruct for $struct_type {
             type Entry = $entry_type;
 
@@ -447,12 +448,12 @@ macro_rules! generate_fam_struct_impl {
 
             fn as_slice(&self) -> &[<Self as FamStruct>::Entry] {
                 let len = self.len();
-                unsafe { self.entries.as_slice(len) }
+                unsafe { self.$entries_name.as_slice(len) }
             }
 
             fn as_mut_slice(&mut self) -> &mut [<Self as FamStruct>::Entry] {
                 let len = self.len();
-                unsafe { self.entries.as_mut_slice(len) }
+                unsafe { self.$entries_name.as_mut_slice(len) }
             }
         }
     };
@@ -505,7 +506,7 @@ mod tests {
         pub entries: __IncompleteArrayField<u32>,
     }
 
-    generate_fam_struct_impl!(MockFamStruct, u32, u32, len, 100);
+    generate_fam_struct_impl!(MockFamStruct, u32, entries, u32, len, 100);
 
     type MockFamStructWrapper = FamStructWrapper<MockFamStruct>;
 


### PR DESCRIPTION
# Description of changes

The macro that generates `impl FamStruct` for structs T with flexible array member now also takes a parameter to be able to specify the name of the flexible array member.

This is required as not all kernel structs having a flexible array member use the same field/member name for the respective member.