### PR TITLE
cargo: Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
+# v0.2.0
+
+* fam: updated the macro that generates implementions of FamStruct to
+  also take a parameter that specifies the name of the flexible array
+  member.
+
 # v0.1.1
 
 * Fixed the Cargo.toml license.
-* Fixed some clippy warnings
+* Fixed some clippy warnings.
 
 # v0.1.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmm-sys-util"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Intel Virtualization Team <vmm-maintainers@intel.com>"]
 description = "A system utility set"
 repository = "https://github.com/rust-vmm/vmm-sys-util"


### PR DESCRIPTION
Release an incremental version to include the new FAM functionality.