### PR TITLE
Block signals handlers when registering a new signal handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.3.0
+
+* Removed `for_vcpu` argument from `signal::register_signal_handler` and
+`signal::validate_signal_num`. Users can now pass absolute values for all valid 
+signal numbers.
+* Removed `flag` argument of `signal::register_signal_handler` public methods,
+which now defaults to `libc::SA_SIGINFO`.
+
 # v0.2.1
 
 * Fixed the FamStructWrapper Clone implementation to avoid UB.

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86.0,
+  "coverage_score": 85.7,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -125,5 +125,4 @@ mod tests {
         let s = rand_alphanumerics(5);
         assert_eq!(5, s.len());
     }
-
 }

--- a/src/timerfd.rs
+++ b/src/timerfd.rs
@@ -264,5 +264,4 @@ mod tests {
         tfd.clear().expect("unable to clear the timer");
         assert_eq!(tfd.is_armed().unwrap(), false);
     }
-
 }


### PR DESCRIPTION
Fixes #52 

Blocked all signals handlers execution when registering
a signal handler, for the registered signal handler.
Refactored SignalHandler enum to a SignalHandler type.

Signed-off-by: Iulian Barbu <iul@amazon.com>