### PR TITLE
fam: fix Clone for FamStructWrapper - bump version to include the fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.idea
 **/*.rs.bk
 Cargo.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.2.1
+
+* Fixed the FamStructWrapper Clone implementation to avoid UB.
+
 # v0.2.0
 
 * fam: updated the macro that generates implementions of FamStruct to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmm-sys-util"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Intel Virtualization Team <vmm-maintainers@intel.com>"]
 description = "A system utility set"
 repository = "https://github.com/rust-vmm/vmm-sys-util"

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -65,15 +65,8 @@ pub enum Error {
 ///     }
 /// }
 ///
-/// impl<T> ::std::clone::Clone for __IncompleteArrayField<T> {
-///     #[inline]
-///     fn clone(&self) -> Self {
-///         Self::new()
-///     }
-/// }
-///
 /// #[repr(C)]
-/// #[derive(Clone, Default)]
+/// #[derive(Default)]
 /// struct MockFamStruct {
 ///     pub len: u32,
 ///     pub padding: u32,
@@ -412,15 +405,13 @@ impl<T: Default + FamStruct> PartialEq for FamStructWrapper<T> {
     }
 }
 
-impl<T: Default + FamStruct + Clone> Clone for FamStructWrapper<T> {
+impl<T: Default + FamStruct> Clone for FamStructWrapper<T> {
     fn clone(&self) -> Self {
-        FamStructWrapper {
-            mem_allocator: self.mem_allocator.to_vec(),
-        }
+        FamStructWrapper::from_entries(self.as_slice())
     }
 }
 
-impl<T: Default + FamStruct + Clone> From<Vec<T>> for FamStructWrapper<T> {
+impl<T: Default + FamStruct> From<Vec<T>> for FamStructWrapper<T> {
     fn from(vec: Vec<T>) -> Self {
         FamStructWrapper { mem_allocator: vec }
     }
@@ -491,15 +482,8 @@ mod tests {
         }
     }
 
-    impl<T> ::std::clone::Clone for __IncompleteArrayField<T> {
-        #[inline]
-        fn clone(&self) -> Self {
-            Self::new()
-        }
-    }
-
     #[repr(C)]
-    #[derive(Clone, Default)]
+    #[derive(Default)]
     struct MockFamStruct {
         pub len: u32,
         pub padding: u32,


### PR DESCRIPTION
FamStructWrapper should not require `Clone` for the fam-struct `T` it safely wraps.
The underlying unsafe fam-struct type `T` cannot safely implement `Clone`. Attempting to reference the fam-member of such a clone can lead to UB.

We can still provide a safe `Clone` for the safe `FamStructWrapper`: instead of cloning the underlying `Vec<T>`, we can simply build a new `FamStructWrapper` using the safe builder starting from the original `[T::Entry]` where we know that `T::Entry` implements `Copy`.

Also bump the version to 0.2.1 to publish a fixed version.