### PR TITLE
tmpfile and tmpdir creation inside /tmp

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.7,
+  "coverage_score": 86.0,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/fallocate.rs
+++ b/src/fallocate.rs
@@ -43,7 +43,7 @@ pub enum FallocateMode {
 /// use vmm_sys_util::fallocate::{fallocate, FallocateMode};
 /// use vmm_sys_util::tempdir::TempDir;
 ///
-/// let tempdir = TempDir::new("/tmp/fallocate_test").unwrap();
+/// let tempdir = TempDir::new_with_prefix("/tmp/fallocate_test").unwrap();
 /// let mut path = PathBuf::from(tempdir.as_path());
 /// path.push("file");
 /// let mut f = OpenOptions::new()

--- a/src/file_traits.rs
+++ b/src/file_traits.rs
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn test_fsync() {
-        let tempdir = TempDir::new("/tmp/fsync_test").unwrap();
+        let tempdir = TempDir::new_with_prefix("/tmp/fsync_test").unwrap();
         let mut path = PathBuf::from(tempdir.as_path());
         path.push("file");
         let mut f = OpenOptions::new()
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn test_set_len() {
-        let tempdir = TempDir::new("/tmp/set_len_test").unwrap();
+        let tempdir = TempDir::new_with_prefix("/tmp/set_len_test").unwrap();
         let mut path = PathBuf::from(tempdir.as_path());
         path.push("file");
         let mut f = OpenOptions::new()

--- a/src/seek_hole.rs
+++ b/src/seek_hole.rs
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn seek_data() {
-        let tempdir = TempDir::new("/tmp/seek_data_test").unwrap();
+        let tempdir = TempDir::new_with_prefix("/tmp/seek_data_test").unwrap();
         let mut path = PathBuf::from(tempdir.as_path());
         path.push("test_file");
         let mut file = File::create(&path).unwrap();
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn seek_hole() {
-        let tempdir = TempDir::new("/tmp/seek_hole_test").unwrap();
+        let tempdir = TempDir::new_with_prefix("/tmp/seek_hole_test").unwrap();
         let mut path = PathBuf::from(tempdir.as_path());
         path.push("test_file");
         let mut file = File::create(&path).unwrap();

--- a/src/write_zeroes.rs
+++ b/src/write_zeroes.rs
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn simple_test() {
-        let tempdir = TempDir::new("/tmp/write_zeroes_test").unwrap();
+        let tempdir = TempDir::new_with_prefix("/tmp/write_zeroes_test").unwrap();
         let mut path = PathBuf::from(tempdir.as_path());
         path.push("file");
         let mut f = OpenOptions::new()
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn large_write_zeroes() {
-        let tempdir = TempDir::new("/tmp/write_zeroes_test").unwrap();
+        let tempdir = TempDir::new_with_prefix("/tmp/write_zeroes_test").unwrap();
         let mut path = PathBuf::from(tempdir.as_path());
         path.push("file");
         let mut f = OpenOptions::new()


### PR DESCRIPTION
Signed-off-by: Iulian Barbu <iul@amazon.com>

Implemented new methods for TempFile struct, respectively for TempDir struct:
- TempFile/TempDir::new() creates a new temp file inside $TMPDIR if set, otherwise inside /tmp.
- TempFile/TempDir::new_in(path) creates a new temp file inside an already existing valid path.
- TempFile/TempDir::new_with_prefix(prefix) is the old TempFile/TempDir::new(prefix) method. 