### PR TITLE
Bumped version to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # v0.3.0
 
 * Removed `for_vcpu` argument from `signal::register_signal_handler` and
-`signal::validate_signal_num`. Users can now pass absolute values for all valid 
-signal numbers.
+  `signal::validate_signal_num`. Users can now pass absolute values for all
+  valid  signal numbers.
 * Removed `flag` argument of `signal::register_signal_handler` public methods,
-which now defaults to `libc::SA_SIGINFO`.
+  which now defaults to `libc::SA_SIGINFO`.
+* Changed `TempFile::new` and `TempDir::new` to create new temporary files/
+  directories inside `$TMPDIR` if set, otherwise inside `/tmp`.
+* Added methods which create temporary files/directories with prefix.
 
 # v0.2.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmm-sys-util"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Intel Virtualization Team <vmm-maintainers@intel.com>"]
 description = "A system utility set"
 repository = "https://github.com/rust-vmm/vmm-sys-util"


### PR DESCRIPTION
With the advent of the new methods from tempfile.rs and tempdir.rs, we should promptly support their usage through a new version of the crate.

Signed-off-by: Iulian Barbu <iul@amazon.com>