### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.3.1
+
+* Advertise functionality for obtaining POSIX real time signal base which is
+  needed to provide absolute signals in the API changed in v0.3.0.
+
 # v0.3.0
 
 * Removed `for_vcpu` argument from `signal::register_signal_handler` and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmm-sys-util"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Intel Virtualization Team <vmm-maintainers@intel.com>"]
 description = "A system utility set"
 repository = "https://github.com/rust-vmm/vmm-sys-util"


### PR DESCRIPTION
Exposing the function that provides the POSIX real time signal base
which is required to effectively use the signal API.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>