### PR TITLE
fam wrappers: add conditional serde compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Added conditionally compiled `serde` compatibility to `FamStructWrapper`,
+  gated by the `with-serde` feature.
+
 # v0.4.0
 
 * Added Windows support for TempFile and errno::Error.
@@ -49,7 +54,8 @@ Firecracker projects, or both.
 
 The first release comes with the following Rust modules:
 
-* aio: Safe wrapper over [`Linux AIO`](http://man7.org/linux/man-pages/man7/aio.7.html).
+* aio: Safe wrapper over
+  [`Linux AIO`](http://man7.org/linux/man-pages/man7/aio.7.html).
 
 * errno: Structures, helpers, and type definitions for working with
   [`errno`](http://man7.org/linux/man-pages/man3/errno.3.html).
@@ -79,8 +85,9 @@ The first release comes with the following Rust modules:
 * signal: Enums, traits and functions for working with
   [`signal`](http://man7.org/linux/man-pages/man7/signal.7.html).
 
-* sockctrl_msg: Wrapper for sending and receiving messages with file descriptors
-  on sockets that accept control messages (e.g. Unix domain sockets).
+* sockctrl_msg: Wrapper for sending and receiving messages with file
+  descriptors on sockets that accept control messages (e.g. Unix domain
+  sockets).
 
 * tempdir: Structure for handling temporary directories.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,13 @@ readme = "README.md"
 keywords = ["utils"]
 license = "Apache-2.0 AND BSD-3-Clause"
 
+[features]
+with-serde = ["serde", "serde_derive"]
+
 [dependencies]
 libc = ">=0.2.39"
+serde = { version = ">=1.0.27", optional = true }
+serde_derive = { version = ">=1.0.27", optional = true }
 
+[dev-dependencies]
+serde_json = ">=1.0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@
 
 #![deny(missing_docs)]
 extern crate libc;
+#[cfg(feature = "with-serde")]
+extern crate serde;
+#[cfg(feature = "with-serde")]
+extern crate serde_derive;
 
 #[cfg(unix)]
 mod unix;


### PR DESCRIPTION
#65

This PR makes `FamStructWrapper`s `serde`-serializable, provided that the wrapped data type is also `serde`-serializable.
The functionality is gated by the `with-serde` compilation feature.
