### PR TITLE
Implement trait std::error::Error for vmm_sys_util::errno::Error

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.7,
+  "coverage_score": 85.8,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -9,6 +9,7 @@
 //! Structures, helpers, and type definitions for working with
 //! [`errno`](http://man7.org/linux/man-pages/man3/errno.3.html).
 
+use std::error::Error as StdError;
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::result;
@@ -103,6 +104,12 @@ impl Display for Error {
     }
 }
 
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        None
+    }
+}
+
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Error::new(e.raw_os_error().unwrap_or_default())
@@ -135,6 +142,7 @@ mod tests {
 
         // Test that the inner value of `Error` corresponds to libc::EBADF.
         assert_eq!(last_err.errno(), libc::EBADF);
+        assert!(last_err.source().is_none());
 
         // Test creating an `Error` from a `std::io::Error`.
         assert_eq!(last_err, Error::from(io::Error::last_os_error()));


### PR DESCRIPTION
Referencing issue #58 , a basic implementation is proposed in this PR.

1. Implemented method `source` from `std::error::Error` for the custom error type `vmm_sys_util::errno::Error`.

2. Added unit test code for above implementation

Personally I think: Since the custom error type `pub struct Error(i32)` is just a wrapper of standard error, therefore there is no underlying error, hence we should always return `None` in the `source` method. Please do correct me if I am wrong. Thanks very much!

Signed-off-by: Henry Wang <<henry.wang@arm.com>>