### PR TITLE
release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.4.0
+
+* Added Windows support for TempFile and errno::Error.
+* Added `into_file` for TempFile which enables the TempFile to be used as a
+  regular file.
+* Implemented std::error::Error for errno::Error.
+* Fixed the implementation of `register_signal_handler` by allowing only
+  valid signal numbers.
+
 # v0.3.1
 
 * Advertise functionality for obtaining POSIX real time signal base which is

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmm-sys-util"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Intel Virtualization Team <vmm-maintainers@intel.com>"]
 description = "A system utility set"
 repository = "https://github.com/rust-vmm/vmm-sys-util"


### PR DESCRIPTION
Updated changelog and version to 0.4.0.

We need to publish a new version so that we can get rid of the `tempfile` dependency in vm-memory.