### PR TITLE
signal: add functionality that waits for a signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Added the `signal::wait_for_signals` function, which suspends execution until
+  either a specified signal or any signal becomes pending, either indefinitely
+  or with a timeout.
+
 # v0.5.0
 
 * Added conditionally compiled `serde` compatibility to `FamStructWrapper`,

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 84.2,
+  "coverage_score": 85.6,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86.2,
+  "coverage_score": 87.7,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Added a function that suspends execution until a specified signal (or for any signal at all) becomes pending, either indefinitely (with [`sigwaitinfo`](https://linux.die.net/man/2/sigtimedwait)) or with a timeout (with [`sigtimedwait`](https://linux.die.net/man/2/sigtimedwait)).