### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.6.0
+
+* Derived Copy for EpollEvent.
+* Implemented Debug for EpollEvent.
+* Changed `Epoll::ctl` signature such that `EpollEvent` is passed by
+  value and not by reference.
+* Enabled this crate to be used on other Unixes (besides Linux) by using
+  target_os = linux where appropriate.
+
 # v0.5.0
 
 * Added conditionally compiled `serde` compatibility to `FamStructWrapper`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmm-sys-util"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Intel Virtualization Team <vmm-maintainers@intel.com>"]
 description = "A system utility set"
 repository = "https://github.com/rust-vmm/vmm-sys-util"


### PR DESCRIPTION
Release v0.6.0. This is needed by https://github.com/rust-vmm/event-manager/issues/15