### PR TITLE
Add Illumos variants of some modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ license = "Apache-2.0 AND BSD-3-Clause"
 with-serde = ["serde", "serde_derive"]
 
 [dependencies]
-libc = ">=0.2.39"
+libc = ">=0.2.74"
 serde = { version = ">=1.0.27", optional = true }
 serde_derive = { version = ">=1.0.27", optional = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "illumos"))'.dependencies]
 bitflags = "1.0"
 
 [dev-dependencies]

--- a/src/illumos/epoll.rs
+++ b/src/illumos/epoll.rs
@@ -10,9 +10,9 @@ use std::os::unix::io::{AsRawFd, RawFd};
 
 use bitflags::bitflags;
 use libc::{
-    epoll_create1, epoll_ctl, epoll_event, epoll_wait, EPOLLERR, EPOLLET, EPOLLHUP, EPOLLIN,
-    EPOLLONESHOT, EPOLLOUT, EPOLLPRI, EPOLLRDHUP, EPOLLWAKEUP, EPOLL_CLOEXEC, EPOLL_CTL_ADD,
-    EPOLL_CTL_DEL, EPOLL_CTL_MOD,
+    epoll_create1, epoll_ctl, epoll_event, epoll_wait, EPOLLERR, EPOLLET, EPOLLEXCLUSIVE, EPOLLHUP,
+    EPOLLIN, EPOLLONESHOT, EPOLLOUT, EPOLLPRI, EPOLLRDHUP, EPOLLWAKEUP, EPOLL_CLOEXEC,
+    EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD,
 };
 
 use crate::syscall::SyscallReturnCode;
@@ -57,6 +57,13 @@ bitflags! {
         const WAKE_UP = EPOLLWAKEUP as u32;
         /// Sets the one-shot behavior for the associated file descriptor.
         const ONE_SHOT = EPOLLONESHOT as u32;
+        /// Sets an exclusive wake up mode for the epoll file descriptor that is being
+        /// attached to the associated file descriptor.
+        /// When a wake up event occurs and multiple epoll file descriptors are attached to
+        /// the same target file using this mode, one or more of the epoll file descriptors
+        /// will receive an event with `epoll_wait`. The default here is for all those file
+        /// descriptors to receive an event.
+        const EXCLUSIVE = EPOLLEXCLUSIVE as u32;
     }
 }
 

--- a/src/illumos/epoll.rs
+++ b/src/illumos/epoll.rs
@@ -1,0 +1,521 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Safe wrappers over the
+//! [`epoll`](http://man7.org/linux/man-pages/man7/epoll.7.html) API.
+
+use std::io;
+use std::ops::{Deref, Drop};
+use std::os::unix::io::{AsRawFd, RawFd};
+
+use bitflags::bitflags;
+use libc::{
+    epoll_create1, epoll_ctl, epoll_event, epoll_wait, EPOLLERR, EPOLLET, EPOLLHUP,
+    EPOLLIN, EPOLLONESHOT, EPOLLOUT, EPOLLPRI, EPOLLRDHUP, EPOLLWAKEUP, EPOLL_CLOEXEC,
+    EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD,
+};
+
+use crate::syscall::SyscallReturnCode;
+
+/// Wrapper over `EPOLL_CTL_*` operations that can be performed on a file descriptor.
+#[repr(i32)]
+pub enum ControlOperation {
+    /// Add a file descriptor to the interest list.
+    Add = EPOLL_CTL_ADD,
+    /// Change the settings associated with a file descriptor that is
+    /// already in the interest list.
+    Modify = EPOLL_CTL_MOD,
+    /// Remove a file descriptor from the interest list.
+    Delete = EPOLL_CTL_DEL,
+}
+
+bitflags! {
+    /// The type of events we can monitor a file descriptor for.
+    pub struct EventSet: u32 {
+        /// The associated file descriptor is available for read operations.
+        const IN = EPOLLIN as u32;
+        /// The associated file descriptor is available for write operations.
+        const OUT = EPOLLOUT as u32;
+        /// Error condition happened on the associated file descriptor.
+        const ERROR = EPOLLERR as u32;
+        /// This can be used to detect peer shutdown when using Edge Triggered monitoring.
+        const READ_HANG_UP = EPOLLRDHUP as u32;
+        /// Sets the Edge Triggered behavior for the associated file descriptor.
+        /// The default behavior is Level Triggered.
+        const EDGE_TRIGGERED = EPOLLET as u32;
+        /// Hang up happened on the associated file descriptor. Note that `epoll_wait`
+        /// will always wait for this event and it is not necessary to set it in events.
+        const HANG_UP = EPOLLHUP as u32;
+        /// There is an exceptional condition on that file descriptor. It is mostly used to
+        /// set high priority for some data.
+        const PRIORITY = EPOLLPRI as u32;
+        /// The event is considered as being "processed" from the time when it is returned
+        /// by a call to `epoll_wait` until the next call to `epoll_wait` on the same
+        /// epoll file descriptor, the closure of that file descriptor, the removal of the
+        /// event file descriptor via EPOLL_CTL_DEL, or the clearing of EPOLLWAKEUP
+        /// for the event file descriptor via EPOLL_CTL_MOD.
+        const WAKE_UP = EPOLLWAKEUP as u32;
+        /// Sets the one-shot behavior for the associated file descriptor.
+        const ONE_SHOT = EPOLLONESHOT as u32;
+    }
+}
+
+/// Wrapper over
+/// ['libc::epoll_event'](https://doc.rust-lang.org/1.8.0/libc/struct.epoll_event.html).
+// We are using `transparent` here to be super sure that this struct and its fields
+// have the same alignment as those from the `epoll_event` struct from C.
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct EpollEvent(epoll_event);
+
+impl std::fmt::Debug for EpollEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{ events: {}, data: {} }}", self.events(), self.data())
+    }
+}
+
+impl Deref for EpollEvent {
+    type Target = epoll_event;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Default for EpollEvent {
+    fn default() -> Self {
+        EpollEvent(epoll_event {
+            events: 0u32,
+            u64: 0u64,
+        })
+    }
+}
+
+impl EpollEvent {
+    /// Create a new epoll_event instance.
+    ///
+    /// # Arguments
+    ///
+    /// `events` - contains an event mask.
+    /// `data` - a user data variable. `data` field can be a fd on which
+    ///          we want to monitor the events specified by `events`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
+    ///
+    /// let event = EpollEvent::new(EventSet::IN, 2);
+    /// ```
+    pub fn new(events: EventSet, data: u64) -> Self {
+        EpollEvent(epoll_event {
+            events: events.bits(),
+            u64: data,
+        })
+    }
+
+    /// Returns the `events` from
+    /// ['libc::epoll_event'](https://doc.rust-lang.org/1.8.0/libc/struct.epoll_event.html).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
+    ///
+    /// let event = EpollEvent::new(EventSet::IN, 2);
+    /// assert_eq!(event.events(), 1);
+    /// ```
+    pub fn events(&self) -> u32 {
+        self.events
+    }
+
+    /// Returns the `EventSet` corresponding to `epoll_event.events`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `libc::epoll_event` contains invalid events.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
+    ///
+    /// let event = EpollEvent::new(EventSet::IN, 2);
+    /// assert_eq!(event.event_set(), EventSet::IN);
+    /// ```
+    pub fn event_set(&self) -> EventSet {
+        // This unwrap is safe because `epoll_events` can only be user created or
+        // initialized by the kernel. We trust the kernel to only send us valid
+        // events. The user can only initialize `epoll_events` using valid events.
+        EventSet::from_bits(self.events()).unwrap()
+    }
+
+    /// Returns the `data` from the `libc::epoll_event`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
+    ///
+    /// let event = EpollEvent::new(EventSet::IN, 2);
+    /// assert_eq!(event.data(), 2);
+    /// ```
+    pub fn data(&self) -> u64 {
+        self.u64
+    }
+
+    /// Converts the `libc::epoll_event` data to a RawFd.
+    ///
+    /// This conversion is lossy when the data does not correspond to a RawFd
+    /// (data does not fit in a i32).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
+    ///
+    /// let event = EpollEvent::new(EventSet::IN, 2);
+    /// assert_eq!(event.fd(), 2);
+    /// ```
+    pub fn fd(&self) -> RawFd {
+        self.u64 as i32
+    }
+}
+
+/// Wrapper over epoll functionality.
+#[derive(Debug)]
+pub struct Epoll {
+    epoll_fd: RawFd,
+}
+
+impl Epoll {
+    /// Create a new epoll file descriptor.
+    pub fn new() -> io::Result<Self> {
+        let epoll_fd = SyscallReturnCode(unsafe { epoll_create1(EPOLL_CLOEXEC) }).into_result()?;
+        Ok(Epoll { epoll_fd })
+    }
+
+    /// Wrapper for `libc::epoll_ctl`.
+    ///
+    /// This can be used for adding, modifying or removing a file descriptor in the
+    /// interest list of the epoll instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `operation` - refers to the action to be performed on the file descriptor.
+    /// * `fd` - the file descriptor on which we want to perform `operation`.
+    /// * `event` - refers to the `epoll_event` instance that is linked to `fd`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    ///
+    /// use std::os::unix::io::AsRawFd;
+    /// use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
+    /// use vmm_sys_util::eventfd::EventFd;
+    ///
+    /// let epoll = Epoll::new().unwrap();
+    /// let event_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+    /// epoll
+    ///     .ctl(
+    ///         ControlOperation::Add,
+    ///         event_fd.as_raw_fd() as i32,
+    ///         EpollEvent::new(EventSet::OUT, event_fd.as_raw_fd() as u64),
+    ///     )
+    ///     .unwrap();
+    /// epoll
+    ///     .ctl(
+    ///         ControlOperation::Modify,
+    ///         event_fd.as_raw_fd() as i32,
+    ///         EpollEvent::new(EventSet::IN, 4),
+    ///     )
+    ///     .unwrap();
+    /// ```
+    pub fn ctl(&self, operation: ControlOperation, fd: RawFd, event: EpollEvent) -> io::Result<()> {
+        // Safe because we give a valid epoll file descriptor, a valid file descriptor to watch,
+        // as well as a valid epoll_event structure. We also check the return value.
+        SyscallReturnCode(unsafe {
+            epoll_ctl(
+                self.epoll_fd,
+                operation as i32,
+                fd,
+                &event as *const EpollEvent as *mut epoll_event,
+            )
+        })
+        .into_empty_result()
+    }
+
+    /// Wrapper for `libc::epoll_wait`.
+    /// Returns the number of file descriptors in the interest list that became ready
+    /// for I/O or `errno` if an error occurred.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_events` - the maximum number of events that we want to be returned in
+    ///                  `events` buffer.
+    /// * `timeout` - specifies for how long the `epoll_wait` system call will block
+    ///               (measured in milliseconds).
+    /// * `events` - points to a memory area that will be used for storing the events
+    ///              returned by `epoll_wait()` call.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    ///
+    /// use std::os::unix::io::AsRawFd;
+    /// use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
+    /// use vmm_sys_util::eventfd::EventFd;
+    ///
+    /// let epoll = Epoll::new().unwrap();
+    /// let event_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+    ///
+    /// let mut ready_events = vec![EpollEvent::default(); 10];
+    /// epoll
+    ///     .ctl(
+    ///         ControlOperation::Add,
+    ///         event_fd.as_raw_fd() as i32,
+    ///         EpollEvent::new(EventSet::OUT, 4),
+    ///     )
+    ///     .unwrap();
+    /// let ev_count = epoll.wait(10, -1, &mut ready_events[..]).unwrap();
+    /// assert_eq!(ev_count, 1);
+    /// ```
+    pub fn wait(
+        &self,
+        max_events: usize,
+        timeout: i32,
+        events: &mut [EpollEvent],
+    ) -> io::Result<usize> {
+        // Safe because we give a valid epoll file descriptor and an array of epoll_event structures
+        // that will be modified by the kernel to indicate information about the subset of file
+        // descriptors in the interest list. We also check the return value.
+        let events_count = SyscallReturnCode(unsafe {
+            epoll_wait(
+                self.epoll_fd,
+                events.as_mut_ptr() as *mut epoll_event,
+                max_events as i32,
+                timeout,
+            )
+        })
+        .into_result()? as usize;
+
+        Ok(events_count)
+    }
+}
+
+impl AsRawFd for Epoll {
+    fn as_raw_fd(&self) -> RawFd {
+        self.epoll_fd
+    }
+}
+
+impl Drop for Epoll {
+    fn drop(&mut self) {
+        // Safe because this fd is opened with `epoll_create` and we trust
+        // the kernel to give us a valid fd.
+        unsafe {
+            libc::close(self.epoll_fd);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::eventfd::EventFd;
+
+    #[test]
+    fn test_event_ops() {
+        let mut event = EpollEvent::default();
+        assert_eq!(event.events(), 0);
+        assert_eq!(event.data(), 0);
+
+        event = EpollEvent::new(EventSet::IN, 2);
+        assert_eq!(event.events(), 1);
+        assert_eq!(event.event_set(), EventSet::IN);
+
+        assert_eq!(event.data(), 2);
+        assert_eq!(event.fd(), 2);
+    }
+
+    #[test]
+    fn test_events_debug() {
+        let events = EpollEvent::new(EventSet::IN, 42);
+        assert_eq!(format!("{:?}", events), "{ events: 1, data: 42 }")
+    }
+
+    #[test]
+    fn test_epoll() {
+        const DEFAULT__TIMEOUT: i32 = 250;
+        const EVENT_BUFFER_SIZE: usize = 128;
+        const MAX_EVENTS: usize = 10;
+
+        let epoll = Epoll::new().unwrap();
+        assert_eq!(epoll.epoll_fd, epoll.as_raw_fd());
+
+        // Let's test different scenarios for `epoll_ctl()` and `epoll_wait()` functionality.
+
+        let event_fd_1 = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        // For EPOLLOUT to be available it is enough only to be possible to write a value of
+        // at least 1 to the eventfd counter without blocking.
+        // If we write a value greater than 0 to this counter, the fd will be available for
+        // EPOLLIN events too.
+        event_fd_1.write(1).unwrap();
+
+        let mut event_1 =
+            EpollEvent::new(EventSet::IN | EventSet::OUT, event_fd_1.as_raw_fd() as u64);
+
+        // For EPOLL_CTL_ADD behavior we will try to add some fds with different event masks into
+        // the interest list of epoll instance.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Add,
+                event_fd_1.as_raw_fd() as i32,
+                event_1
+            )
+            .is_ok());
+
+        // We can't add twice the same fd to epoll interest list.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Add,
+                event_fd_1.as_raw_fd() as i32,
+                event_1
+            )
+            .is_err());
+
+        let event_fd_2 = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        event_fd_2.write(1).unwrap();
+        assert!(epoll
+            .ctl(
+                ControlOperation::Add,
+                event_fd_2.as_raw_fd() as i32,
+                // For this fd, we want an Event instance that has `data` field set to other
+                // value than the value of the fd and `events` without EPOLLIN type set.
+                EpollEvent::new(EventSet::OUT, 10)
+            )
+            .is_ok());
+
+        // For the following eventfd we won't write anything to its counter, so we expect EPOLLIN
+        // event to not be available for this fd, even if we say that we want to monitor this type
+        // of event via EPOLL_CTL_ADD operation.
+        let event_fd_3 = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        let event_3 = EpollEvent::new(EventSet::OUT | EventSet::IN, event_fd_3.as_raw_fd() as u64);
+        assert!(epoll
+            .ctl(
+                ControlOperation::Add,
+                event_fd_3.as_raw_fd() as i32,
+                event_3
+            )
+            .is_ok());
+
+        // Let's check `epoll_wait()` behavior for our epoll instance.
+        let mut ready_events = vec![EpollEvent::default(); EVENT_BUFFER_SIZE];
+        let mut ev_count = epoll
+            .wait(MAX_EVENTS, DEFAULT__TIMEOUT, &mut ready_events[..])
+            .unwrap();
+
+        // We expect to have 3 fds in the ready list of epoll instance.
+        assert_eq!(ev_count, 3);
+
+        // Let's check also the Event values that are now returned in the ready list.
+        assert_eq!(ready_events[0].data(), event_fd_1.as_raw_fd() as u64);
+        // For this fd, `data` field was populated with random data instead of the
+        // corresponding fd value.
+        assert_eq!(ready_events[1].data(), 10);
+        assert_eq!(ready_events[2].data(), event_fd_3.as_raw_fd() as u64);
+
+        // EPOLLIN and EPOLLOUT should be available for this fd.
+        assert_eq!(
+            ready_events[0].events(),
+            (EventSet::IN | EventSet::OUT).bits()
+        );
+        // Only EPOLLOUT is expected because we didn't want to monitor EPOLLIN on this fd.
+        assert_eq!(ready_events[1].events(), EventSet::OUT.bits());
+        // Only EPOLLOUT too because eventfd counter value is 0 (we didn't write a value
+        // greater than 0 to it).
+        assert_eq!(ready_events[2].events(), EventSet::OUT.bits());
+
+        // Now we're gonna modify the Event instance for a fd to test EPOLL_CTL_MOD
+        // behavior.
+        // We create here a new Event with some events, other than those previously set,
+        // that we want to monitor this time on event_fd_1.
+        event_1 = EpollEvent::new(EventSet::OUT, 20);
+        assert!(epoll
+            .ctl(
+                ControlOperation::Modify,
+                event_fd_1.as_raw_fd() as i32,
+                event_1
+            )
+            .is_ok());
+
+        let event_fd_4 = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        // Can't modify a fd that wasn't added to epoll interest list.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Modify,
+                event_fd_4.as_raw_fd() as i32,
+                EpollEvent::default()
+            )
+            .is_err());
+
+        let _ = epoll
+            .wait(MAX_EVENTS, DEFAULT__TIMEOUT, &mut ready_events[..])
+            .unwrap();
+
+        // Let's check that Event fields were indeed changed for the `event_fd_1` fd.
+        assert_eq!(ready_events[0].data(), 20);
+        // EPOLLOUT is now available for this fd as we've intended with EPOLL_CTL_MOD operation.
+        assert_eq!(ready_events[0].events(), EventSet::OUT.bits());
+
+        // Now let's set for a fd to not have any events monitored.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Modify,
+                event_fd_1.as_raw_fd() as i32,
+                EpollEvent::default()
+            )
+            .is_ok());
+
+        // In this particular case we expect to remain only with 2 fds in the ready list.
+        ev_count = epoll
+            .wait(MAX_EVENTS, DEFAULT__TIMEOUT, &mut ready_events[..])
+            .unwrap();
+        assert_eq!(ev_count, 2);
+
+        // Let's also delete a fd from the interest list.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Delete,
+                event_fd_2.as_raw_fd() as i32,
+                EpollEvent::default()
+            )
+            .is_ok());
+
+        // We expect to have only one fd remained in the ready list (event_fd_3).
+        ev_count = epoll
+            .wait(MAX_EVENTS, DEFAULT__TIMEOUT, &mut ready_events[..])
+            .unwrap();
+
+        assert_eq!(ev_count, 1);
+        assert_eq!(ready_events[0].data(), event_fd_3.as_raw_fd() as u64);
+        assert_eq!(ready_events[0].events(), EventSet::OUT.bits());
+
+        // If we try to remove a fd from epoll interest list that wasn't added before it will fail.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Delete,
+                event_fd_4.as_raw_fd() as i32,
+                EpollEvent::default()
+            )
+            .is_err());
+    }
+}

--- a/src/illumos/epoll.rs
+++ b/src/illumos/epoll.rs
@@ -10,9 +10,9 @@ use std::os::unix::io::{AsRawFd, RawFd};
 
 use bitflags::bitflags;
 use libc::{
-    epoll_create1, epoll_ctl, epoll_event, epoll_wait, EPOLLERR, EPOLLET, EPOLLHUP,
-    EPOLLIN, EPOLLONESHOT, EPOLLOUT, EPOLLPRI, EPOLLRDHUP, EPOLLWAKEUP, EPOLL_CLOEXEC,
-    EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD,
+    epoll_create1, epoll_ctl, epoll_event, epoll_wait, EPOLLERR, EPOLLET, EPOLLHUP, EPOLLIN,
+    EPOLLONESHOT, EPOLLOUT, EPOLLPRI, EPOLLRDHUP, EPOLLWAKEUP, EPOLL_CLOEXEC, EPOLL_CTL_ADD,
+    EPOLL_CTL_DEL, EPOLL_CTL_MOD,
 };
 
 use crate::syscall::SyscallReturnCode;

--- a/src/illumos/eventfd.rs
+++ b/src/illumos/eventfd.rs
@@ -1,0 +1,214 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
+//! Structure and wrapper functions for working with
+//! [`eventfd`](http://man7.org/linux/man-pages/man2/eventfd.2.html).
+
+use std::fs::File;
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::{io, mem, result};
+
+use libc::{c_void, dup, eventfd, read, write};
+
+// Reexport commonly used flags from libc.
+pub use libc::{EFD_CLOEXEC, EFD_NONBLOCK, EFD_SEMAPHORE};
+
+/// A safe wrapper around Linux
+/// [`eventfd`](http://man7.org/linux/man-pages/man2/eventfd.2.html).
+pub struct EventFd {
+    eventfd: File,
+}
+
+impl EventFd {
+    /// Create a new EventFd with an initial value.
+    ///
+    /// # Arguments
+    ///
+    /// * `flag`: The initial value used for creating the `EventFd`.
+    /// Refer to Linux [`eventfd`](http://man7.org/linux/man-pages/man2/eventfd.2.html).
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+    ///
+    /// EventFd::new(EFD_NONBLOCK).unwrap();
+    /// ```
+    pub fn new(flag: i32) -> result::Result<EventFd, io::Error> {
+        // This is safe because eventfd merely allocated an eventfd for
+        // our process and we handle the error case.
+        let ret = unsafe { eventfd(0, flag) };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            // This is safe because we checked ret for success and know
+            // the kernel gave us an fd that we own.
+            Ok(EventFd {
+                eventfd: unsafe { File::from_raw_fd(ret) },
+            })
+        }
+    }
+
+    /// Add a value to the eventfd's counter.
+    ///
+    /// When the addition causes the counter overflow, this would either block
+    /// until a [`read`](http://man7.org/linux/man-pages/man2/read.2.html) is
+    /// performed on the file descriptor, or fail with the
+    /// error EAGAIN if the file descriptor has been made nonblocking.
+    ///
+    /// # Arguments
+    ///
+    /// * `v`: the value to be added to the eventfd's counter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+    ///
+    /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+    /// evt.write(55).unwrap();
+    /// ```
+    pub fn write(&self, v: u64) -> result::Result<(), io::Error> {
+        // This is safe because we made this fd and the pointer we pass
+        // can not overflow because we give the syscall's size parameter properly.
+        let ret = unsafe {
+            write(
+                self.as_raw_fd(),
+                &v as *const u64 as *const c_void,
+                mem::size_of::<u64>(),
+            )
+        };
+        if ret <= 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Read a value from the eventfd.
+    ///
+    /// If the counter is zero, this would either block
+    /// until the counter becomes nonzero, or fail with the
+    /// error EAGAIN if the file descriptor has been made nonblocking.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+    ///
+    /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+    /// evt.write(55).unwrap();
+    /// assert_eq!(evt.read().unwrap(), 55);
+    /// ```
+    pub fn read(&self) -> result::Result<u64, io::Error> {
+        let mut buf: u64 = 0;
+        let ret = unsafe {
+            // This is safe because we made this fd and the pointer we
+            // pass can not overflow because we give the syscall's size parameter properly.
+            read(
+                self.as_raw_fd(),
+                &mut buf as *mut u64 as *mut c_void,
+                mem::size_of::<u64>(),
+            )
+        };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(buf)
+        }
+    }
+
+    /// Clone this EventFd.
+    ///
+    /// This internally creates a new file descriptor and it will share the same
+    /// underlying count within the kernel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate vmm_sys_util;
+    /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+    ///
+    /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+    /// let evt_clone = evt.try_clone().unwrap();
+    /// evt.write(923).unwrap();
+    /// assert_eq!(evt_clone.read().unwrap(), 923);
+    /// ```
+    pub fn try_clone(&self) -> result::Result<EventFd, io::Error> {
+        // This is safe because we made this fd and properly check that it returns without error.
+        let ret = unsafe { dup(self.as_raw_fd()) };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            // This is safe because we checked ret for success and know the kernel gave us an fd that we
+            // own.
+            Ok(EventFd {
+                eventfd: unsafe { File::from_raw_fd(ret) },
+            })
+        }
+    }
+}
+
+impl AsRawFd for EventFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.eventfd.as_raw_fd()
+    }
+}
+
+impl FromRawFd for EventFd {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        EventFd {
+            eventfd: File::from_raw_fd(fd),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        EventFd::new(EFD_NONBLOCK).unwrap();
+        EventFd::new(0).unwrap();
+    }
+
+    #[test]
+    fn test_read_write() {
+        let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        evt.write(55).unwrap();
+        assert_eq!(evt.read().unwrap(), 55);
+    }
+
+    #[test]
+    fn test_write_overflow() {
+        let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        evt.write(std::u64::MAX - 1).unwrap();
+        let r = evt.write(1);
+        match r {
+            Err(ref inner) if inner.kind() == io::ErrorKind::WouldBlock => (),
+            _ => panic!("Unexpected"),
+        }
+    }
+    #[test]
+    fn test_read_nothing() {
+        let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        let r = evt.read();
+        match r {
+            Err(ref inner) if inner.kind() == io::ErrorKind::WouldBlock => (),
+            _ => panic!("Unexpected"),
+        }
+    }
+    #[test]
+    fn test_clone() {
+        let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        let evt_clone = evt.try_clone().unwrap();
+        evt.write(923).unwrap();
+        assert_eq!(evt_clone.read().unwrap(), 923);
+    }
+}

--- a/src/illumos/mod.rs
+++ b/src/illumos/mod.rs
@@ -1,0 +1,5 @@
+pub mod eventfd;
+pub mod epoll;
+pub mod seek_hole;
+pub mod signal;
+pub mod write_zeroes;

--- a/src/illumos/mod.rs
+++ b/src/illumos/mod.rs
@@ -1,5 +1,5 @@
-pub mod eventfd;
 pub mod epoll;
+pub mod eventfd;
 pub mod seek_hole;
 pub mod signal;
 pub mod write_zeroes;

--- a/src/illumos/seek_hole.rs
+++ b/src/illumos/seek_hole.rs
@@ -1,0 +1,229 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
+//! Traits and implementations over [lseek](https://illumos.org/man/2/lseek).
+
+use std::fs::File;
+use std::io::{Error, Result};
+use std::os::unix::io::AsRawFd;
+
+use libc::{lseek as libc_lseek, ENXIO, SEEK_DATA, SEEK_HOLE};
+
+/// A trait for seeking to the next hole or non-hole position in a file.
+pub trait SeekHole {
+    /// Seek to the first hole in a file.
+    ///
+    /// Seek at a position greater than or equal to `offset`. If no holes exist
+    /// after `offset`, the seek position will be set to the end of the file.
+    /// If `offset` is at or after the end of the file, the seek position is
+    /// unchanged, and None is returned.
+    ///
+    /// Returns the current seek position after the seek or an error.
+    fn seek_hole(&mut self, offset: u64) -> Result<Option<u64>>;
+
+    /// Seek to the first data in a file.
+    ///
+    /// Seek at a position greater than or equal to `offset`.
+    /// If no data exists after `offset`, the seek position is unchanged,
+    /// and None is returned.
+    ///
+    /// Returns the current offset after the seek or an error.
+    fn seek_data(&mut self, offset: u64) -> Result<Option<u64>>;
+}
+
+//#[cfg(target_env = "musl")]
+//const SEEK_DATA: c_int = 3;
+//#[cfg(target_env = "musl")]
+//const SEEK_HOLE: c_int = 4;
+
+// Safe wrapper for `libc::lseek()`
+fn lseek(file: &mut File, offset: i64, whence: i32) -> Result<Option<u64>> {
+    // This is safe because we pass a known-good file descriptor.
+    let res = unsafe { libc_lseek(file.as_raw_fd(), offset, whence) };
+
+    if res < 0 {
+        // Convert ENXIO into None; pass any other error as-is.
+        let err = Error::last_os_error();
+        if let Some(errno) = Error::raw_os_error(&err) {
+            if errno == ENXIO {
+                return Ok(None);
+            }
+        }
+        Err(err)
+    } else {
+        Ok(Some(res as u64))
+    }
+}
+
+impl SeekHole for File {
+    fn seek_hole(&mut self, offset: u64) -> Result<Option<u64>> {
+        lseek(self, offset as i64, SEEK_HOLE)
+    }
+
+    fn seek_data(&mut self, offset: u64) -> Result<Option<u64>> {
+        lseek(self, offset as i64, SEEK_DATA)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tempdir::TempDir;
+    use std::fs::File;
+    use std::io::{Seek, SeekFrom, Write};
+    use std::path::PathBuf;
+
+    fn seek_cur(file: &mut File) -> u64 {
+        file.seek(SeekFrom::Current(0)).unwrap()
+    }
+
+    #[test]
+    fn seek_data() {
+	// Note: the behavior of Illumos is different here, because tmpfs on
+	// Illumos doesn't fully support SEEK_DATA in lseek. Outside of /tmp,
+	// Illumos has the same behavior as Linux.
+        let tempdir = TempDir::new_with_prefix("seek_data_test").unwrap();
+        let mut path = PathBuf::from(tempdir.as_path());
+        path.push("test_file");
+        let mut file = File::create(&path).unwrap();
+
+        // Empty file
+        assert_eq!(file.seek_data(0).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0);
+
+        // File with non-zero length consisting entirely of a hole
+        file.set_len(0x10000).unwrap();
+        file.sync_all().unwrap();
+        assert_eq!(file.seek_data(0).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0);
+
+        // seek_data at or after the end of the file should return None
+        assert_eq!(file.seek_data(0x10000).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0);
+        assert_eq!(file.seek_data(0x10001).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0);
+
+        // Write some data to [0x10000, 0x20000)
+        let b = [0x55u8; 0x10000];
+        file.seek(SeekFrom::Start(0x10000)).unwrap();
+        file.write_all(&b).unwrap();
+        assert_eq!(file.seek_data(0).unwrap(), Some(0x10000));
+        assert_eq!(seek_cur(&mut file), 0x10000);
+
+        // seek_data within data should return the same offset
+        assert_eq!(file.seek_data(0x10000).unwrap(), Some(0x10000));
+        assert_eq!(seek_cur(&mut file), 0x10000);
+        assert_eq!(file.seek_data(0x10001).unwrap(), Some(0x10001));
+        assert_eq!(seek_cur(&mut file), 0x10001);
+        assert_eq!(file.seek_data(0x1FFFF).unwrap(), Some(0x1FFFF));
+        assert_eq!(seek_cur(&mut file), 0x1FFFF);
+
+        // Extend the file to add another hole after the data
+        file.set_len(0x30000).unwrap();
+        assert_eq!(file.seek_data(0).unwrap(), Some(0x10000));
+        assert_eq!(seek_cur(&mut file), 0x10000);
+        assert_eq!(file.seek_data(0x1FFFF).unwrap(), Some(0x1FFFF));
+        assert_eq!(seek_cur(&mut file), 0x1FFFF);
+        assert_eq!(file.seek_data(0x20000).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0x1FFFF);
+    }
+
+    #[test]
+    #[allow(clippy::cognitive_complexity)]
+    fn seek_hole() {
+	// Note: the behavior of Illumos is different here, because tmpfs on
+	// Illumos doesn't fully support SEEK_HOLE in lseek. Outside of /tmp,
+	// Illumos has the same behavior as Linux.
+        let tempdir = TempDir::new_with_prefix("seek_hole_test").unwrap();
+        let mut path = PathBuf::from(tempdir.as_path());
+        path.push("test_file");
+        let mut file = File::create(&path).unwrap();
+
+        // Empty file
+        assert_eq!(file.seek_hole(0).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0);
+
+        // File with non-zero length consisting entirely of a hole
+        file.set_len(0x10000).unwrap();
+        file.sync_all().unwrap();
+        assert_eq!(file.seek_hole(0).unwrap(), Some(0));
+        assert_eq!(seek_cur(&mut file), 0);
+        assert_eq!(file.seek_hole(0xFFFF).unwrap(), Some(0xFFFF));
+        assert_eq!(seek_cur(&mut file), 0xFFFF);
+
+        // seek_hole at or after the end of the file should return None
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x10000).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0);
+        assert_eq!(file.seek_hole(0x10001).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0);
+
+        // Write some data to [0x10000, 0x20000)
+        let b = [0x55u8; 0x10000];
+        file.seek(SeekFrom::Start(0x10000)).unwrap();
+        file.write_all(&b).unwrap();
+
+        // seek_hole within a hole should return the same offset
+        //assert_eq!(file.seek_hole(0).unwrap(), Some(0));
+        //assert_eq!(seek_cur(&mut file), 0);
+        //assert_eq!(file.seek_hole(0xFFFF).unwrap(), Some(0xFFFF));
+        //assert_eq!(seek_cur(&mut file), 0xFFFF);
+
+        // seek_hole within data should return the next hole (EOF)
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x10000).unwrap(), Some(0x20000));
+        assert_eq!(seek_cur(&mut file), 0x20000);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x10001).unwrap(), Some(0x20000));
+        assert_eq!(seek_cur(&mut file), 0x20000);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x1FFFF).unwrap(), Some(0x20000));
+        assert_eq!(seek_cur(&mut file), 0x20000);
+
+        // seek_hole at EOF after data should return None
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x20000).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0);
+
+        // Extend the file to add another hole after the data
+        file.set_len(0x30000).unwrap();
+        assert_eq!(file.seek_hole(0).unwrap(), Some(0));
+        assert_eq!(seek_cur(&mut file), 0);
+        assert_eq!(file.seek_hole(0xFFFF).unwrap(), Some(0xFFFF));
+        assert_eq!(seek_cur(&mut file), 0xFFFF);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x10000).unwrap(), Some(0x20000));
+        assert_eq!(seek_cur(&mut file), 0x20000);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x1FFFF).unwrap(), Some(0x20000));
+        assert_eq!(seek_cur(&mut file), 0x20000);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x20000).unwrap(), Some(0x20000));
+        assert_eq!(seek_cur(&mut file), 0x20000);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x20001).unwrap(), Some(0x20001));
+        assert_eq!(seek_cur(&mut file), 0x20001);
+
+        // seek_hole at EOF after a hole should return None
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x30000).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0);
+
+        // Write some data to [0x20000, 0x30000)
+        file.seek(SeekFrom::Start(0x20000)).unwrap();
+        file.write_all(&b).unwrap();
+
+        // seek_hole within [0x20000, 0x30000) should now find the hole at EOF
+        assert_eq!(file.seek_hole(0x20000).unwrap(), Some(0x30000));
+        assert_eq!(seek_cur(&mut file), 0x30000);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x20001).unwrap(), Some(0x30000));
+        assert_eq!(seek_cur(&mut file), 0x30000);
+        file.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(file.seek_hole(0x30000).unwrap(), None);
+        assert_eq!(seek_cur(&mut file), 0);
+    }
+}

--- a/src/illumos/signal.rs
+++ b/src/illumos/signal.rs
@@ -11,8 +11,8 @@
 
 use libc::{
     c_int, c_void, pthread_kill, pthread_sigmask, pthread_t, sigaction, sigaddset, sigemptyset,
-    sigfillset, siginfo_t, sigismember, sigset_t, 
-    EINVAL, SIG_BLOCK, SIG_UNBLOCK, sysconf, _SC_SIGRT_MIN, _SC_SIGRT_MAX,
+    sigfillset, siginfo_t, sigismember, sigset_t, sysconf, EINVAL, SIG_BLOCK, SIG_UNBLOCK,
+    _SC_SIGRT_MAX, _SC_SIGRT_MIN,
 };
 
 use crate::errno;
@@ -95,14 +95,14 @@ pub type SignalHandler =
 #[allow(non_snake_case)]
 pub fn SIGRTMIN() -> c_int {
     unsafe { sysconf(_SC_SIGRT_MIN) as c_int }
-//    unsafe { __libc_current_sigrtmin() }
+    //    unsafe { __libc_current_sigrtmin() }
 }
 
 /// Return the maximum (inclusive) real-time signal number.
 #[allow(non_snake_case)]
 pub fn SIGRTMAX() -> c_int {
     unsafe { sysconf(_SC_SIGRT_MAX) as c_int }
-//    unsafe { __libc_current_sigrtmax() }
+    //    unsafe { __libc_current_sigrtmax() }
 }
 
 /// Verify that a signal number is valid.
@@ -462,5 +462,4 @@ mod tests {
         unblock_signal(signal).unwrap();
         assert!(!get_blocked_signals().unwrap().contains(&(signal)));
     }
-
 }

--- a/src/illumos/signal.rs
+++ b/src/illumos/signal.rs
@@ -1,0 +1,466 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
+//! Enums, traits and functions for working with
+//! [`signal`](http://man7.org/linux/man-pages/man7/signal.7.html).
+
+use libc::{
+    c_int, c_void, pthread_kill, pthread_sigmask, pthread_t, sigaction, sigaddset, sigemptyset,
+    sigfillset, siginfo_t, sigismember, sigset_t, 
+    EINVAL, SIG_BLOCK, SIG_UNBLOCK, sysconf, _SC_SIGRT_MIN, _SC_SIGRT_MAX,
+};
+
+use crate::errno;
+use std::fmt::{self, Display};
+use std::io;
+use std::mem;
+use std::os::unix::thread::JoinHandleExt;
+use std::ptr::{null, null_mut};
+use std::result;
+use std::thread::JoinHandle;
+
+/// The error cases enumeration for signal handling.
+#[derive(Debug)]
+pub enum Error {
+    /// Couldn't create a sigset.
+    CreateSigset(errno::Error),
+    /// The wrapped signal has already been blocked.
+    SignalAlreadyBlocked(c_int),
+    /// Failed to check if the requested signal is in the blocked set already.
+    CompareBlockedSignals(errno::Error),
+    /// The signal could not be blocked.
+    BlockSignal(errno::Error),
+    /// The signal mask could not be retrieved.
+    RetrieveSignalMask(c_int),
+    /// The signal could not be unblocked.
+    UnblockSignal(errno::Error),
+    /// Failed to wait for given signal.
+    ClearWaitPending(errno::Error),
+    /// Failed to get pending signals.
+    ClearGetPending(errno::Error),
+    /// Failed to check if given signal is in the set of pending signals.
+    ClearCheckPending(errno::Error),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+
+        match self {
+            CreateSigset(e) => write!(f, "couldn't create a sigset: {}", e),
+            SignalAlreadyBlocked(num) => write!(f, "signal {} already blocked", num),
+            CompareBlockedSignals(e) => write!(
+                f,
+                "failed to check whether requested signal is in the blocked set: {}",
+                e,
+            ),
+            BlockSignal(e) => write!(f, "signal could not be blocked: {}", e),
+            RetrieveSignalMask(errno) => write!(
+                f,
+                "failed to retrieve signal mask: {}",
+                io::Error::from_raw_os_error(*errno),
+            ),
+            UnblockSignal(e) => write!(f, "signal could not be unblocked: {}", e),
+            ClearWaitPending(e) => write!(f, "failed to wait for given signal: {}", e),
+            ClearGetPending(e) => write!(f, "failed to get pending signals: {}", e),
+            ClearCheckPending(e) => write!(
+                f,
+                "failed to check whether given signal is in the pending set: {}",
+                e,
+            ),
+        }
+    }
+}
+
+/// A simplified [Result](https://doc.rust-lang.org/std/result/enum.Result.html) type
+/// for operations that can return [`Error`](Enum.error.html).
+pub type SignalResult<T> = result::Result<T, Error>;
+
+/// Public alias for a signal handler.
+/// [`sigaction`](http://man7.org/linux/man-pages/man2/sigaction.2.html).
+pub type SignalHandler =
+    extern "C" fn(num: c_int, info: *mut siginfo_t, _unused: *mut c_void) -> ();
+
+//extern "C" {
+//    fn __libc_current_sigrtmin() -> c_int;
+//    fn __libc_current_sigrtmax() -> c_int;
+//}
+
+/// Return the minimum (inclusive) real-time signal number.
+#[allow(non_snake_case)]
+pub fn SIGRTMIN() -> c_int {
+    unsafe { sysconf(_SC_SIGRT_MIN) as c_int }
+//    unsafe { __libc_current_sigrtmin() }
+}
+
+/// Return the maximum (inclusive) real-time signal number.
+#[allow(non_snake_case)]
+pub fn SIGRTMAX() -> c_int {
+    unsafe { sysconf(_SC_SIGRT_MAX) as c_int }
+//    unsafe { __libc_current_sigrtmax() }
+}
+
+/// Verify that a signal number is valid.
+///
+/// Supported signals range from `SIGHUP` to `SIGSYS` and from `SIGRTMIN` to `SIGRTMAX`.
+/// We recommend using realtime signals `[SIGRTMIN(), SIGRTMAX()]` for VCPU threads.
+///
+/// # Arguments
+///
+/// * `num`: the signal number to be verified.
+///
+/// # Examples
+///
+/// ```
+/// extern crate vmm_sys_util;
+/// use vmm_sys_util::signal::validate_signal_num;
+///
+/// let num = validate_signal_num(1).unwrap();
+/// ```
+pub fn validate_signal_num(num: c_int) -> errno::Result<()> {
+    if (libc::SIGHUP <= num && num <= libc::SIGSYS) || (SIGRTMIN() <= num && num <= SIGRTMAX()) {
+        Ok(())
+    } else {
+        Err(errno::Error::new(EINVAL))
+    }
+}
+
+/// Register the signal handler of `signum`.
+///
+/// # Safety
+///
+/// This is considered unsafe because the given handler will be called
+/// asynchronously, interrupting whatever the thread was doing and therefore
+/// must only do async-signal-safe operations.
+///
+/// # Arguments
+///
+/// * `num`: the signal number to be registered.
+/// * `handler`: the signal handler function to register.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate libc;
+/// extern crate vmm_sys_util;
+/// # use libc::{c_int, c_void, siginfo_t, SA_SIGINFO};
+/// use vmm_sys_util::signal::{register_signal_handler, SignalHandler};
+///
+/// extern "C" fn handle_signal(_: c_int, _: *mut siginfo_t, _: *mut c_void) {}
+/// register_signal_handler(0, handle_signal);
+/// ```
+
+pub fn register_signal_handler(num: c_int, handler: SignalHandler) -> errno::Result<()> {
+    validate_signal_num(num)?;
+
+    // signum specifies the signal and can be any valid signal except
+    // SIGKILL and SIGSTOP.
+    // [`sigaction`](http://man7.org/linux/man-pages/man2/sigaction.2.html).
+    if libc::SIGKILL == num || libc::SIGSTOP == num {
+        return Err(errno::Error::new(EINVAL));
+    }
+
+    // Safe, because this is a POD struct.
+    let mut act: sigaction = unsafe { mem::zeroed() };
+    act.sa_sigaction = handler as *const () as usize;
+    act.sa_flags = libc::SA_SIGINFO;
+
+    // Block all signals while the `handler` is running.
+    // Blocking other signals is needed to make sure the execution of
+    // the handler continues uninterrupted if another signal comes.
+    if unsafe { sigfillset(&mut act.sa_mask as *mut sigset_t) } < 0 {
+        return errno::errno_result();
+    }
+
+    // Safe because the parameters are valid and we check the return value.
+    match unsafe { sigaction(num, &act, null_mut()) } {
+        0 => Ok(()),
+        _ => errno::errno_result(),
+    }
+}
+
+/// Create a `sigset` with given signals.
+///
+/// An array of signal numbers are added into the signal set by
+/// [`sigaddset`](http://man7.org/linux/man-pages/man3/sigaddset.3p.html).
+/// This is a helper function used when we want to manipulate signals.
+///
+/// # Arguments
+///
+/// * `signals`: signal numbers to be added to the new `sigset`.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate libc;
+/// extern crate vmm_sys_util;
+/// # use libc::sigismember;
+/// use vmm_sys_util::signal::create_sigset;
+///
+/// let sigset = create_sigset(&[1]).unwrap();
+///
+/// unsafe { assert_eq!(sigismember(&sigset, 1), 1); }
+/// ```
+pub fn create_sigset(signals: &[c_int]) -> errno::Result<sigset_t> {
+    // sigset will actually be initialized by sigemptyset below.
+    let mut sigset: sigset_t = unsafe { mem::zeroed() };
+
+    // Safe - return value is checked.
+    let ret = unsafe { sigemptyset(&mut sigset) };
+    if ret < 0 {
+        return errno::errno_result();
+    }
+
+    for signal in signals {
+        // Safe - return value is checked.
+        let ret = unsafe { sigaddset(&mut sigset, *signal) };
+        if ret < 0 {
+            return errno::errno_result();
+        }
+    }
+
+    Ok(sigset)
+}
+
+/// Retrieve the signal mask that is blocked of the current thread.
+///
+/// Use [`pthread_sigmask`](http://man7.org/linux/man-pages/man3/pthread_sigmask.3.html)
+/// to fetch the signal mask which is blocked for the caller, return the signal mask as
+/// a vector of c_int.
+///
+/// # Examples
+///
+/// ```
+/// extern crate vmm_sys_util;
+/// use vmm_sys_util::signal::{block_signal, get_blocked_signals};
+///
+/// block_signal(1).unwrap();
+/// assert!(get_blocked_signals().unwrap().contains(&(1)));
+/// ```
+pub fn get_blocked_signals() -> SignalResult<Vec<c_int>> {
+    let mut mask = Vec::new();
+
+    // Safe - return values are checked.
+    unsafe {
+        let mut old_sigset: sigset_t = mem::zeroed();
+        let ret = pthread_sigmask(SIG_BLOCK, null(), &mut old_sigset as *mut sigset_t);
+        if ret < 0 {
+            return Err(Error::RetrieveSignalMask(ret));
+        }
+
+        for num in 0..=SIGRTMAX() {
+            if sigismember(&old_sigset, num) > 0 {
+                mask.push(num);
+            }
+        }
+    }
+
+    Ok(mask)
+}
+
+/// Mask a given signal.
+///
+/// Set the given signal `num` as blocked.
+/// If signal is already blocked, the call will fail with
+/// [`SignalAlreadyBlocked`](enum.Error.html#variant.SignalAlreadyBlocked).
+///
+/// # Arguments
+///
+/// * `num`: the signal to be masked.
+///
+/// # Examples
+///
+/// ```
+/// extern crate vmm_sys_util;
+/// use vmm_sys_util::signal::block_signal;
+///
+/// block_signal(1).unwrap();
+/// ```
+pub fn block_signal(num: c_int) -> SignalResult<()> {
+    let sigset = create_sigset(&[num]).map_err(Error::CreateSigset)?;
+
+    // Safe - return values are checked.
+    unsafe {
+        let mut old_sigset: sigset_t = mem::zeroed();
+        let ret = pthread_sigmask(SIG_BLOCK, &sigset, &mut old_sigset as *mut sigset_t);
+        if ret < 0 {
+            return Err(Error::BlockSignal(errno::Error::last()));
+        }
+        // Check if the given signal is already blocked.
+        let ret = sigismember(&old_sigset, num);
+        if ret < 0 {
+            return Err(Error::CompareBlockedSignals(errno::Error::last()));
+        } else if ret > 0 {
+            return Err(Error::SignalAlreadyBlocked(num));
+        }
+    }
+    Ok(())
+}
+
+/// Unmask a given signal.
+///
+/// # Arguments
+///
+/// * `num`: the signal to be unmasked.
+///
+/// # Examples
+///
+/// ```
+/// extern crate vmm_sys_util;
+/// use vmm_sys_util::signal::{block_signal, get_blocked_signals, unblock_signal};
+///
+/// block_signal(1).unwrap();
+/// assert!(get_blocked_signals().unwrap().contains(&(1)));
+/// unblock_signal(1).unwrap();
+/// ```
+pub fn unblock_signal(num: c_int) -> SignalResult<()> {
+    let sigset = create_sigset(&[num]).map_err(Error::CreateSigset)?;
+
+    // Safe - return value is checked.
+    let ret = unsafe { pthread_sigmask(SIG_UNBLOCK, &sigset, null_mut()) };
+    if ret < 0 {
+        return Err(Error::UnblockSignal(errno::Error::last()));
+    }
+    Ok(())
+}
+
+/// Trait for threads that can be signalled via `pthread_kill`.
+///
+/// Note that this is only useful for signals between `SIGRTMIN()` and
+/// `SIGRTMAX()` because these are guaranteed to not be used by the C
+/// runtime.
+///
+/// # Safety
+///
+/// This is marked unsafe because the implementation of this trait must
+/// guarantee that the returned `pthread_t` is valid and has a lifetime at
+/// least that of the trait object.
+pub unsafe trait Killable {
+    /// Cast this killable thread as `pthread_t`.
+    fn pthread_handle(&self) -> pthread_t;
+
+    /// Send a signal to this killable thread.
+    ///
+    /// # Arguments
+    ///
+    /// * `num`: specify the signal
+    fn kill(&self, num: c_int) -> errno::Result<()> {
+        validate_signal_num(num)?;
+
+        // Safe because we ensure we are using a valid pthread handle,
+        // a valid signal number, and check the return result.
+        let ret = unsafe { pthread_kill(self.pthread_handle(), num) };
+        if ret < 0 {
+            return errno::errno_result();
+        }
+        Ok(())
+    }
+}
+
+// Safe because we fulfill our contract of returning a genuine pthread handle.
+unsafe impl<T> Killable for JoinHandle<T> {
+    fn pthread_handle(&self) -> pthread_t {
+        // JoinHandleExt::as_pthread_t gives c_ulong, convert it to the
+        // type that the libc crate expects
+        //assert_eq!(mem::size_of::<pthread_t>(), mem::size_of::<usize>());
+        self.as_pthread_t() as usize as pthread_t
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    // Reserve for each vcpu signal.
+    static mut SIGNAL_HANDLER_CALLED: bool = false;
+
+    extern "C" fn handle_signal(_: c_int, _: *mut siginfo_t, _: *mut c_void) {
+        unsafe {
+            // In the tests, there only uses vcpu signal.
+            SIGNAL_HANDLER_CALLED = true;
+        }
+    }
+
+    #[test]
+    fn test_register_signal_handler() {
+        // testing bad value
+        assert!(register_signal_handler(libc::SIGKILL, handle_signal).is_err());
+        assert!(register_signal_handler(libc::SIGSTOP, handle_signal).is_err());
+        assert!(register_signal_handler(SIGRTMAX() + 1, handle_signal).is_err());
+        format!("{:?}", register_signal_handler(SIGRTMAX(), handle_signal));
+        assert!(register_signal_handler(SIGRTMIN(), handle_signal).is_ok());
+        assert!(register_signal_handler(libc::SIGSYS, handle_signal).is_ok());
+    }
+
+    #[test]
+    #[allow(clippy::empty_loop)]
+    fn test_killing_thread() {
+        let killable = thread::spawn(|| thread::current().id());
+        let killable_id = killable.join().unwrap();
+        assert_ne!(killable_id, thread::current().id());
+
+        // We install a signal handler for the specified signal; otherwise the whole process will
+        // be brought down when the signal is received, as part of the default behaviour. Signal
+        // handlers are global, so we install this before starting the thread.
+        register_signal_handler(SIGRTMIN(), handle_signal)
+            .expect("failed to register vcpu signal handler");
+
+        let killable = thread::spawn(|| loop {});
+
+        let res = killable.kill(SIGRTMAX() + 1);
+        assert!(res.is_err());
+        format!("{:?}", res);
+
+        unsafe {
+            assert!(!SIGNAL_HANDLER_CALLED);
+        }
+
+        assert!(killable.kill(SIGRTMIN()).is_ok());
+
+        // We're waiting to detect that the signal handler has been called.
+        const MAX_WAIT_ITERS: u32 = 20;
+        let mut iter_count = 0;
+        loop {
+            thread::sleep(Duration::from_millis(100));
+
+            if unsafe { SIGNAL_HANDLER_CALLED } {
+                break;
+            }
+
+            iter_count += 1;
+            // timeout if we wait too long
+            assert!(iter_count <= MAX_WAIT_ITERS);
+        }
+
+        // Our signal handler doesn't do anything which influences the killable thread, so the
+        // previous signal is effectively ignored. If we were to join killable here, we would block
+        // forever as the loop keeps running. Since we don't join, the thread will become detached
+        // as the handle is dropped, and will be killed when the process/main thread exits.
+    }
+
+    #[test]
+    fn test_block_unblock_signal() {
+        let signal = SIGRTMIN();
+
+        // Check if it is blocked.
+        unsafe {
+            let mut sigset: sigset_t = mem::zeroed();
+            pthread_sigmask(SIG_BLOCK, null(), &mut sigset as *mut sigset_t);
+            assert_eq!(sigismember(&sigset, signal), 0);
+        }
+
+        block_signal(signal).unwrap();
+        assert!(get_blocked_signals().unwrap().contains(&(signal)));
+
+        unblock_signal(signal).unwrap();
+        assert!(!get_blocked_signals().unwrap().contains(&(signal)));
+    }
+
+}

--- a/src/illumos/write_zeroes.rs
+++ b/src/illumos/write_zeroes.rs
@@ -1,0 +1,149 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+//
+// Copyright 2018 The Chromium OS Authors. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
+//! Traits for replacing a range with a hole and writing zeroes in a file.
+
+use std::cmp::min;
+use std::io::{Result, Seek, Write};
+
+/// A trait for writing zeroes to a stream.
+pub trait WriteZeroes {
+    /// Write zeroes to a stream.
+    ///
+    /// Write `length` bytes of zeroes to the stream, returning how many
+    /// bytes were written.
+    fn write_zeroes(&mut self, length: usize) -> Result<usize>;
+}
+
+impl<T: Seek + Write> WriteZeroes for T {
+    fn write_zeroes(&mut self, length: usize) -> Result<usize> {
+        // write a buffer of zeroes until we have written up to length.
+        let buf_size = min(length, 0x10000);
+        let buf = vec![0u8; buf_size];
+        let mut nwritten: usize = 0;
+        while nwritten < length {
+            let remaining = length - nwritten;
+            let write_size = min(remaining, buf_size);
+            nwritten += self.write(&buf[0..write_size])?;
+        }
+        Ok(length)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unused_io_amount)]
+mod tests {
+    use super::*;
+    use std::fs::OpenOptions;
+    use std::io::{Read, Seek, SeekFrom};
+    use std::path::PathBuf;
+
+    use crate::tempdir::TempDir;
+
+    #[test]
+    fn simple_test() {
+        let tempdir = TempDir::new_with_prefix("/tmp/write_zeroes_test").unwrap();
+        let mut path = PathBuf::from(tempdir.as_path());
+        path.push("file");
+        let mut f = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .unwrap();
+        f.set_len(16384).unwrap();
+
+        // Write buffer of non-zero bytes to offset 1234
+        let orig_data = [0x55u8; 5678];
+        f.seek(SeekFrom::Start(1234)).unwrap();
+        f.write(&orig_data).unwrap();
+
+        // Read back the data plus some overlap on each side
+        let mut readback = [0u8; 16384];
+        f.seek(SeekFrom::Start(0)).unwrap();
+        f.read(&mut readback).unwrap();
+        // Bytes before the write should still be 0
+        for read in readback[0..1234].iter() {
+            assert_eq!(*read, 0);
+        }
+        // Bytes that were just written should be 0x55
+        for read in readback[1234..(1234 + 5678)].iter() {
+            assert_eq!(*read, 0x55);
+        }
+        // Bytes after the written area should still be 0
+        for read in readback[(1234 + 5678)..].iter() {
+            assert_eq!(*read, 0);
+        }
+
+        // Overwrite some of the data with zeroes
+        f.seek(SeekFrom::Start(2345)).unwrap();
+        f.write_zeroes(4321).expect("write_zeroes failed");
+        // Verify seek position after write_zeroes()
+        assert_eq!(f.seek(SeekFrom::Current(0)).unwrap(), 2345 + 4321);
+
+        // Read back the data and verify that it is now zero
+        f.seek(SeekFrom::Start(0)).unwrap();
+        f.read(&mut readback).unwrap();
+        // Bytes before the write should still be 0
+        for read in readback[0..1234].iter() {
+            assert_eq!(*read, 0);
+        }
+        // Original data should still exist before the write_zeroes region
+        for read in readback[1234..2345].iter() {
+            assert_eq!(*read, 0x55);
+        }
+        // The write_zeroes region should now be zero
+        for read in readback[2345..(2345 + 4321)].iter() {
+            assert_eq!(*read, 0);
+        }
+        // Original data should still exist after the write_zeroes region
+        for read in readback[(2345 + 4321)..(1234 + 5678)].iter() {
+            assert_eq!(*read, 0x55);
+        }
+        // The rest of the file should still be 0
+        for read in readback[(1234 + 5678)..].iter() {
+            assert_eq!(*read, 0);
+        }
+    }
+
+    #[test]
+    fn large_write_zeroes() {
+        let tempdir = TempDir::new_with_prefix("/tmp/write_zeroes_test").unwrap();
+        let mut path = PathBuf::from(tempdir.as_path());
+        path.push("file");
+        let mut f = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .unwrap();
+        f.set_len(16384).unwrap();
+
+        // Write buffer of non-zero bytes
+        let orig_data = [0x55u8; 0x20000];
+        f.seek(SeekFrom::Start(0)).unwrap();
+        f.write(&orig_data).unwrap();
+
+        // Overwrite some of the data with zeroes
+        f.seek(SeekFrom::Start(0)).unwrap();
+        f.write_zeroes(0x10001).expect("write_zeroes failed");
+        // Verify seek position after write_zeroes()
+        assert_eq!(f.seek(SeekFrom::Current(0)).unwrap(), 0x10001);
+
+        // Read back the data and verify that it is now zero
+        let mut readback = [0u8; 0x20000];
+        f.seek(SeekFrom::Start(0)).unwrap();
+        f.read(&mut readback).unwrap();
+        // The write_zeroes region should now be zero
+        for read in readback[0..0x10001].iter() {
+            assert_eq!(*read, 0);
+        }
+        // Original data should still exist after the write_zeroes region
+        for read in readback[0x10001..0x20000].iter() {
+            assert_eq!(*read, 0x55);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,11 @@ mod unix;
 #[cfg(unix)]
 pub use crate::unix::*;
 
+#[cfg(target_os = "illumos")]
+mod illumos;
+#[cfg(target_os = "illumos")]
+pub use crate::illumos::*;
+
 pub mod errno;
 pub mod fam;
 pub mod rand;


### PR DESCRIPTION
This PR adds some variants of the Linux submodules, modified to work on Illumos. They depend on changes to Rust's libc released in version 0.2.74, and also depend on nightly Rust for the new target_os="illumos".

For now, this is a draft PR, because it still has some failing tests in src/illumos/seek_hole.rs, related to a few small but fundamental differences in the behavior of `lseek` between Linux and Illumos. I'd appreciate feedback on the approach, even though it's not quite ready to merge.