### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.7.0
+
+* Switched to Rust edition 2018.
+* Added the `metric` module that provides a `Metric` interface as well as a
+  default implementation for `AtomicU64`.
+
 # v0.6.1
 
 * Implemented `From<io::Error>` for `errno::Error`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmm-sys-util"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Intel Virtualization Team <vmm-maintainers@intel.com>"]
 description = "A system utility set"
 repository = "https://github.com/rust-vmm/vmm-sys-util"


### PR DESCRIPTION
Preparing a new release of vmm-sys-util.

This release includes the metric module, and the changes required for switching this crate to edition 2018.