### PR TITLE
CI: use upstream docker plugin

### DIFF
--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -8,7 +8,7 @@ steps:
       platform: x86_64
       os: windows
     plugins:
-      - petrutlucian94/docker#v3.1.1:
+      - docker#v3.7.0:
           image: "lpetrut/rust_win_buildtools"
           always-pull: true
 
@@ -20,7 +20,7 @@ steps:
       platform: x86_64
       os: windows
     plugins:
-      - petrutlucian94/docker#v3.1.1:
+      - docker#v3.7.0:
           image: "lpetrut/rust_win_buildtools"
           always-pull: true
 
@@ -33,7 +33,7 @@ steps:
       platform: x86_64
       os: windows
     plugins:
-      - petrutlucian94/docker#v3.1.1:
+      - docker#v3.7.0:
           image: "lpetrut/rust_win_buildtools"
           always-pull: true
 
@@ -46,7 +46,7 @@ steps:
       platform: x86_64
       os: windows
     plugins:
-      - petrutlucian94/docker#v3.1.1:
+      - docker#v3.7.0:
           image: "lpetrut/rust_win_buildtools"
           always-pull: true
 
@@ -59,7 +59,7 @@ steps:
       platform: x86_64
       os: windows
     plugins:
-      - petrutlucian94/docker#v3.1.1:
+      - docker#v3.7.0:
           image: "lpetrut/rust_win_buildtools"
           always-pull: true
           environment:


### PR DESCRIPTION
When we first added the Buildkite pipelines, there were some bugs in the
Buildkite docker plugin which did not allow us to use the upstream
version. We can now switch to upstream again.

Signed-off-by: Andreea Florescu <fandree@amazon.com>