### PR TITLE
Don't assert that file size is unchanged for test_large_write_zeroes

### DIFF
--- a/src/linux/write_zeroes.rs
+++ b/src/linux/write_zeroes.rs
@@ -268,10 +268,6 @@ mod tests {
         for read in &readback[(0x1_8001 + 0x200)..SIZE] {
             assert_eq!(*read, NON_ZERO_VALUE);
         }
-
-        // It's ok to write zeroes after the end of the file, but the file size should not change.
-        assert!(f.write_all_zeroes_at(SIZE as u64 - 0x200, 0x400).is_ok());
-        assert_eq!(f.metadata().unwrap().len(), SIZE as u64);
     }
 
     #[test]


### PR DESCRIPTION
When fallocate fails in File's implementation of write_zeroes_at,
the fallback behavior is to write zeroes with write_at(); however,
this requires extending the filesize. Remove the assertion that
expects the filesize to remain the same -- otherwise tests will
spuriously fail on a system where fallocate returns -EOPNOTSUPP.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>