### PR TITLE
tempdir: fix test assuming that TMPDIR=/tmp

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.7,
+  "coverage_score": 87.6,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/unix/tempdir.rs
+++ b/src/unix/tempdir.rs
@@ -146,7 +146,7 @@ mod tests {
         let path = t.as_path();
         assert!(path.exists());
         assert!(path.is_dir());
-        assert!(path.starts_with("/tmp/"));
+        assert!(path.starts_with(temp_dir()));
     }
 
     #[test]


### PR DESCRIPTION
I had TMPDIR set to /run/user/1000, and this made this test fail.

Signed-off-by: Alyssa Ross <hi@alyssa.is>
