### PR TITLE
derive Debug for fam & eventfd

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.6,
+  "coverage_score": 87.4,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -142,6 +142,7 @@ pub unsafe trait FamStruct {
 /// A wrapper for [`FamStruct`](trait.FamStruct.html).
 ///
 /// It helps in treating a [`FamStruct`](trait.FamStruct.html) similarly to an actual `Vec`.
+#[derive(Debug)]
 pub struct FamStructWrapper<T: Default + FamStruct> {
     // This variable holds the FamStruct structure. We use a `Vec<T>` to make the allocation
     // large enough while still being aligned for `T`. Only the first element of `Vec<T>`

--- a/src/linux/eventfd.rs
+++ b/src/linux/eventfd.rs
@@ -18,6 +18,7 @@ pub use libc::{EFD_CLOEXEC, EFD_NONBLOCK, EFD_SEMAPHORE};
 
 /// A safe wrapper around Linux
 /// [`eventfd`](http://man7.org/linux/man-pages/man2/eventfd.2.html).
+#[derive(Debug)]
 pub struct EventFd {
     eventfd: File,
 }


### PR DESCRIPTION
The fam debug implementation is rather dummy, but it still helps with
debugging by allowing the derive on structures containing a fam struct.