### PR TITLE
Fix warnings and adjust test coverage

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.4,
+  "coverage_score": 87.1,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -35,6 +35,8 @@ pub enum Error {
 
 /// Trait for accessing properties of C defined FAM structures.
 ///
+/// # Safety
+///
 /// This is unsafe due to the number of constraints that aren't checked:
 /// * the implementer should be a POD
 /// * the implementor should contain a flexible array member of elements of type `Entry`

--- a/src/linux/poll.rs
+++ b/src/linux/poll.rs
@@ -997,10 +997,10 @@ mod tests {
         };
 
         assert_eq!(ev.token(), 0x10);
-        assert_eq!(ev.readable(), true);
-        assert_eq!(ev.writable(), true);
-        assert_eq!(ev.hungup(), true);
-        assert_eq!(ev.has_error(), true);
+        assert!(ev.readable());
+        assert!(ev.writable());
+        assert!(ev.hungup());
+        assert!(ev.has_error());
         assert_eq!(
             ev.raw_events(),
             (EPOLLIN | EPOLLERR | EPOLLOUT | EPOLLHUP) as u32

--- a/src/linux/sock_ctrl_msg.rs
+++ b/src/linux/sock_ctrl_msg.rs
@@ -426,6 +426,8 @@ impl ScmSocket for UnixStream {
 /// Trait for types that can be converted into an `iovec` that can be referenced by a syscall for
 /// the lifetime of this object.
 ///
+/// # Safety
+///
 /// This is marked unsafe because the implementation must ensure that the returned pointer and size
 /// is valid and that the lifetime of the returned pointer is at least that of the trait object.
 pub unsafe trait IntoIovec {

--- a/src/linux/timerfd.rs
+++ b/src/linux/timerfd.rs
@@ -234,7 +234,7 @@ mod tests {
     fn test_from_raw_fd() {
         let ret = unsafe { timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC) };
         let tfd = unsafe { TimerFd::from_raw_fd(ret) };
-        assert_eq!(tfd.is_armed().unwrap(), false);
+        assert!(!tfd.is_armed().unwrap());
     }
 
     #[test]
@@ -246,20 +246,20 @@ mod tests {
     #[test]
     fn test_one_shot() {
         let mut tfd = TimerFd::new().expect("failed to create timerfd");
-        assert_eq!(tfd.is_armed().unwrap(), false);
+        assert!(!tfd.is_armed().unwrap());
 
         let dur = Duration::from_millis(200);
         let now = Instant::now();
         tfd.reset(dur, None).expect("failed to arm timer");
 
-        assert_eq!(tfd.is_armed().unwrap(), true);
+        assert!(tfd.is_armed().unwrap());
 
         let count = tfd.wait().expect("unable to wait for timer");
 
         assert_eq!(count, 1);
         assert!(now.elapsed() >= dur);
         tfd.clear().expect("unable to clear the timer");
-        assert_eq!(tfd.is_armed().unwrap(), false);
+        assert!(!tfd.is_armed().unwrap());
     }
 
     #[test]
@@ -275,6 +275,6 @@ mod tests {
         let count = tfd.wait().expect("unable to wait for timer");
         assert!(count >= 5, "count = {}", count);
         tfd.clear().expect("unable to clear the timer");
-        assert_eq!(tfd.is_armed().unwrap(), false);
+        assert!(!tfd.is_armed().unwrap());
     }
 }

--- a/src/unix/terminal.rs
+++ b/src/unix/terminal.rs
@@ -64,6 +64,8 @@ fn set_flags(fd: RawFd, flags: c_int) -> Result<()> {
 /// Trait for file descriptors that are TTYs, according to
 /// [`isatty`](http://man7.org/linux/man-pages/man3/isatty.3.html).
 ///
+/// # Safety
+///
 /// This is marked unsafe because the implementation must ensure that the returned
 /// RawFd is a valid fd and that the lifetime of the returned fd is at least that
 /// of the trait object.


### PR DESCRIPTION
This PR includes the original one from dependabot #156 
It fixes clippy warnings and test coverage due to updated Rust version.