### PR TITLE
Implementing `std::error::Error` for `fam::Error`

### DIFF
--- a/src/fam.rs
+++ b/src/fam.rs
@@ -20,7 +20,6 @@
 use serde::de::{self, Deserialize, Deserializer, SeqAccess, Visitor};
 #[cfg(feature = "with-serde")]
 use serde::{ser::SerializeTuple, Serialize, Serializer};
-#[cfg(feature = "with-serde")]
 use std::fmt;
 #[cfg(feature = "with-serde")]
 use std::marker::PhantomData;
@@ -31,6 +30,16 @@ use std::mem::{self, size_of};
 pub enum Error {
     /// The max size has been exceeded
     SizeLimitExceeded,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::SizeLimitExceeded => write!(f, "The max size has been exceeded"),
+        }
+    }
 }
 
 /// Trait for accessing properties of C defined FAM structures.


### PR DESCRIPTION
### Summary of the PR

`vmm_sys_util::fam::Error` does not currently implement `std::error::Error`.

This introduces issues when attempting to write an error which contains this.

For example the below code is not possible without this trait implementation:
```rust
#[derive(Debug,thiserror::Error)]
pub enum MyError {
    #[error("My error A {0:?}")]
    A(#[from] vmm_sys_util::fam::Error),
    // ...
}
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
