### PR TITLE
Fix panic caused by rand_bytes()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## Unreleased
+
+### Changed
+- [[#178](https://github.com/rust-vmm/vmm-sys-util/issues/178)]: Fixed a bug in
+  `rand_bytes` that was triggering a panic when the number of bytes was not a
+  multiple of 4.
 
 ## v0.11.0
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -81,10 +81,10 @@ fn rand_alphanumerics_impl(rand_fn: &dyn Fn() -> u32, len: usize) -> OsString {
 
 fn rand_bytes_impl(rand_fn: &dyn Fn() -> u32, len: usize) -> Vec<u8> {
     let mut buf: Vec<Vec<u8>> = Vec::new();
-    let mut num = len;
+    let mut num = if len % 4 == 0 { len / 4 } else { len / 4 + 1 };
     while num > 0 {
         buf.push(xor_pseudo_rng_u8_bytes(rand_fn));
-        num -= 4;
+        num -= 1;
     }
     buf.into_iter().flatten().take(len).collect()
 }
@@ -156,7 +156,8 @@ mod tests {
 
     #[test]
     fn test_rand_bytes() {
-        let s = rand_bytes(8);
-        assert_eq!(8, s.len());
+        for i in 0..8 {
+            assert_eq!(i, rand_bytes(i).len());
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Vibha Acharya <vibharya@amazon.co.uk>

### Summary of the PR

rand_bytes() causes a panic when number of bytes requested are not multiples of 4.
`'main' panicked at 'attempt to subtract with overflow'`

Relates to : #178

The unit test was testing for 8 which is why it passed.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
