### PR TITLE
[TempFile] Revert to using `mkstemp` on unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - [[#178](https://github.com/rust-vmm/vmm-sys-util/issues/178)]: Fixed a bug in
   `rand_bytes` that was triggering a panic when the number of bytes was not a
   multiple of 4.
+- [[#181](https://github.com/rust-vmm/vmm-sys-util/pull/181)]: Changed
+  `TempFile::new_with_prefix()` on linux to use `mkstemp` to prevent name 
+  collisions.
 
 ## v0.11.0
 


### PR DESCRIPTION
### Summary of the PR

The name generation in `TempFile` is done by appending a randomly generated string of 6 alphanumeric characters to a prefix-path. This PR changes that implementation back ot using `mkstemp` on unix systems, to prevent name collisions. This additionally brings it inline with the `TempDir` implementation in the `unix::tempdir` module.

It seems that on windows something similar is possible via `GetTempFileName`, but I am too unfamiliar with the win32 api (and also have no windows machine available for testing) to be confident in implementing that change. 

### Reason

We encountered spurious failures in tests due to multiple parallel running tests generating the same random file name. 

### Open Questions

- Does this need a unit test?
- The (now windows-only) implementation of `TempDir::new_with_prefix` uses `.truncate(true)`, which silently overwrites existing temporary files in the case of a name collision. Should this be changed?

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
