### PR TITLE
linux: {seek_hole, write_zeroes}: Fix clippy issue

### DIFF
--- a/src/linux/seek_hole.rs
+++ b/src/linux/seek_hole.rs
@@ -84,7 +84,7 @@ mod tests {
     use std::path::PathBuf;
 
     fn seek_cur(file: &mut File) -> u64 {
-        file.seek(SeekFrom::Current(0)).unwrap()
+        file.stream_position().unwrap()
     }
 
     #[test]
@@ -154,7 +154,7 @@ mod tests {
         assert_eq!(seek_cur(&mut file), 0xFFFF);
 
         // seek_hole at or after the end of the file should return None
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x10000).unwrap(), None);
         assert_eq!(seek_cur(&mut file), 0);
         assert_eq!(file.seek_hole(0x10001).unwrap(), None);
@@ -172,18 +172,18 @@ mod tests {
         assert_eq!(seek_cur(&mut file), 0xFFFF);
 
         // seek_hole within data should return the next hole (EOF)
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x10000).unwrap(), Some(0x20000));
         assert_eq!(seek_cur(&mut file), 0x20000);
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x10001).unwrap(), Some(0x20000));
         assert_eq!(seek_cur(&mut file), 0x20000);
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x1FFFF).unwrap(), Some(0x20000));
         assert_eq!(seek_cur(&mut file), 0x20000);
 
         // seek_hole at EOF after data should return None
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x20000).unwrap(), None);
         assert_eq!(seek_cur(&mut file), 0);
 
@@ -193,21 +193,21 @@ mod tests {
         assert_eq!(seek_cur(&mut file), 0);
         assert_eq!(file.seek_hole(0xFFFF).unwrap(), Some(0xFFFF));
         assert_eq!(seek_cur(&mut file), 0xFFFF);
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x10000).unwrap(), Some(0x20000));
         assert_eq!(seek_cur(&mut file), 0x20000);
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x1FFFF).unwrap(), Some(0x20000));
         assert_eq!(seek_cur(&mut file), 0x20000);
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x20000).unwrap(), Some(0x20000));
         assert_eq!(seek_cur(&mut file), 0x20000);
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x20001).unwrap(), Some(0x20001));
         assert_eq!(seek_cur(&mut file), 0x20001);
 
         // seek_hole at EOF after a hole should return None
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x30000).unwrap(), None);
         assert_eq!(seek_cur(&mut file), 0);
 
@@ -218,10 +218,10 @@ mod tests {
         // seek_hole within [0x20000, 0x30000) should now find the hole at EOF
         assert_eq!(file.seek_hole(0x20000).unwrap(), Some(0x30000));
         assert_eq!(seek_cur(&mut file), 0x30000);
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x20001).unwrap(), Some(0x30000));
         assert_eq!(seek_cur(&mut file), 0x30000);
-        file.seek(SeekFrom::Start(0)).unwrap();
+        file.rewind().unwrap();
         assert_eq!(file.seek_hole(0x30000).unwrap(), None);
         assert_eq!(seek_cur(&mut file), 0);
     }


### PR DESCRIPTION
### Summary of the PR

Fix clippy issue from latest clippy about use of SeekFrom::Start(0)
rather than .rewind()

This allows rust-vmm-ci update.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
