### PR TITLE
Disable compilation of Atomic64 code in metric.rs if there's no Atomic64

### DIFF
--- a/src/metric.rs
+++ b/src/metric.rs
@@ -11,6 +11,8 @@
 //! of these components can choose what metrics they’re interested in and also
 //! can add their own custom metrics without the need to maintain forks.
 
+#![cfg(target_has_atomic = "64")]
+
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Abstraction over the common metric operations.


### PR DESCRIPTION
Atomic64 is not present, at least, on armel, mipsel and x32 platforms.  Disable compilation of metrics.rs which enhances this data type.