### PR TITLE
linux/timerfd: stop explicitly casting to c_long for timespec.tv_nsec

### DIFF
--- a/src/linux/timerfd.rs
+++ b/src/linux/timerfd.rs
@@ -71,9 +71,7 @@ impl TimerFd {
         {
             spec.it_value.tv_sec = dur.as_secs() as libc::time_t;
         }
-        // nsec always fits in i32 because subsec_nanos is defined to be less than one billion.
-        let nsec = dur.subsec_nanos() as i32;
-        spec.it_value.tv_nsec = libc::c_long::from(nsec);
+        spec.it_value.tv_nsec = dur.subsec_nanos() as _;
 
         if let Some(int) = interval {
             // https://github.com/rust-lang/libc/issues/1848
@@ -81,9 +79,7 @@ impl TimerFd {
             {
                 spec.it_interval.tv_sec = int.as_secs() as libc::time_t;
             }
-            // nsec always fits in i32 because subsec_nanos is defined to be less than one billion.
-            let nsec = int.subsec_nanos() as i32;
-            spec.it_interval.tv_nsec = libc::c_long::from(nsec);
+            spec.it_interval.tv_nsec = int.subsec_nanos() as _;
         }
 
         // SAFETY: Safe because this doesn't modify any memory and we check the return value.


### PR DESCRIPTION
struct timespec.tv_nsec is implementation-specific (even if the doc says it is c_long). For example, on x32 it is i64.  Do not explicitly cast nsec value to c_long, use whatever type needed for the target type.  This also simplifies the code (avoiding temporary variable).