### PR TITLE
fix: `missing_debug_implementations`

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.1,
+  "coverage_score": 85.6,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! Collection of modules that provides helpers and utilities used by multiple
 //! [rust-vmm](https://github.com/rust-vmm/community) components.
 
-#![deny(missing_docs)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux;

--- a/src/linux/epoll.rs
+++ b/src/linux/epoll.rs
@@ -19,6 +19,7 @@ use libc::{
 use crate::syscall::SyscallReturnCode;
 
 /// Wrapper over `EPOLL_CTL_*` operations that can be performed on a file descriptor.
+#[derive(Debug)]
 #[repr(i32)]
 pub enum ControlOperation {
     /// Add a file descriptor to the interest list.

--- a/src/linux/fallocate.rs
+++ b/src/linux/fallocate.rs
@@ -14,6 +14,7 @@ use crate::errno::{errno_result, Error, Result};
 /// Operation to be performed on a given range when calling [`fallocate`]
 ///
 /// [`fallocate`]: fn.fallocate.html
+#[derive(Debug)]
 pub enum FallocateMode {
     /// Deallocating file space.
     PunchHole,

--- a/src/linux/poll.rs
+++ b/src/linux/poll.rs
@@ -47,6 +47,12 @@ const POLL_CONTEXT_MAX_EVENTS: usize = 16;
 /// This should only be used with [`EpollContext`](struct.EpollContext.html).
 pub struct EpollEvents(RefCell<[epoll_event; POLL_CONTEXT_MAX_EVENTS]>);
 
+impl std::fmt::Debug for EpollEvents {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EpollEvents {{ ... }}")
+    }
+}
+
 impl EpollEvents {
     /// Creates a new EpollEvents.
     pub fn new() -> EpollEvents {
@@ -142,6 +148,15 @@ pub struct PollEvent<'a, T> {
     token: PhantomData<T>, // Needed to satisfy usage of T
 }
 
+impl<T> std::fmt::Debug for PollEvent<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PollEvent")
+            .field("event", &"?")
+            .field("token", &self.token)
+            .finish()
+    }
+}
+
 impl<'a, T: PollToken> PollEvent<'a, T> {
     /// Gets the token associated in
     /// [`PollContext::add`](struct.PollContext.html#method.add) with this event.
@@ -189,6 +204,7 @@ impl<'a, T: PollToken> PollEvent<'a, T> {
 
 /// An iterator over a subset of events returned by
 /// [`PollContext::wait`](struct.PollContext.html#method.wait).
+#[derive(Debug)]
 pub struct PollEventIter<'a, I, T>
 where
     I: Iterator<Item = &'a epoll_event>,
@@ -220,6 +236,16 @@ pub struct PollEvents<'a, T> {
     count: usize,
     events: Ref<'a, [epoll_event; POLL_CONTEXT_MAX_EVENTS]>,
     tokens: PhantomData<[T]>, // Needed to satisfy usage of T
+}
+
+impl<T> std::fmt::Debug for PollEvents<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PollEventsOwned")
+            .field("count", &self.count)
+            .field("events", &"?")
+            .field("tokens", &self.tokens)
+            .finish()
+    }
 }
 
 impl<'a, T: PollToken> PollEvents<'a, T> {
@@ -270,6 +296,16 @@ pub struct PollEventsOwned<T> {
     tokens: PhantomData<T>, // Needed to satisfy usage of T
 }
 
+impl<T> std::fmt::Debug for PollEventsOwned<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PollEventsOwned")
+            .field("count", &self.count)
+            .field("events", &"?")
+            .field("tokens", &self.tokens)
+            .finish()
+    }
+}
+
 impl<T: PollToken> PollEventsOwned<T> {
     /// Creates borrowed structure from owned structure
     /// [`PollEventsOwned`](struct.PollEventsOwned.html).
@@ -286,7 +322,7 @@ impl<T: PollToken> PollEventsOwned<T> {
 }
 
 /// Watching events taken by [`PollContext`](struct.PollContext.html).
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct WatchingEvents(u32);
 
 impl WatchingEvents {
@@ -355,6 +391,7 @@ impl WatchingEvents {
 ///     assert_eq!(event.token(), 1);
 /// }
 /// ```
+#[derive(Debug)]
 pub struct EpollContext<T> {
     epoll_ctx: File,
     // Needed to satisfy usage of T
@@ -699,6 +736,7 @@ impl<T: PollToken> IntoRawFd for EpollContext<T> {
 /// let tokens: Vec<u32> = pollevents.iter_readable().map(|e| e.token()).collect();
 /// assert_eq!(&tokens[..], &[2]);
 /// ```
+#[derive(Debug)]
 pub struct PollContext<T> {
     epoll_ctx: EpollContext<T>,
 

--- a/src/linux/timerfd.rs
+++ b/src/linux/timerfd.rs
@@ -19,6 +19,7 @@ use crate::errno::{errno_result, Result};
 
 /// A safe wrapper around a Linux
 /// [`timerfd`](http://man7.org/linux/man-pages/man2/timerfd_create.2.html).
+#[derive(Debug)]
 pub struct TimerFd(File);
 
 impl TimerFd {

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -6,6 +6,7 @@
 use std::os::raw::c_int;
 
 /// Wrapper to interpret syscall exit codes and provide a rustacean `io::Result`.
+#[derive(Debug)]
 pub struct SyscallReturnCode(pub c_int);
 
 impl SyscallReturnCode {

--- a/src/tempfile.rs
+++ b/src/tempfile.rs
@@ -39,6 +39,7 @@ use crate::errno::{errno_result, Error, Result};
 /// Wrapper for working with temporary files.
 ///
 /// The file will be maintained for the lifetime of the `TempFile` object.
+#[derive(Debug)]
 pub struct TempFile {
     path: PathBuf,
     file: Option<File>,

--- a/src/unix/tempdir.rs
+++ b/src/unix/tempdir.rs
@@ -16,6 +16,7 @@ use crate::errno::{errno_result, Error, Result};
 /// Wrapper over a temporary directory.
 ///
 /// The directory will be maintained for the lifetime of the `TempDir` object.
+#[derive(Debug)]
 pub struct TempDir {
     path: PathBuf,
 }


### PR DESCRIPTION
### Summary of the PR

Sets `missing_debug_implementations` to deny and adds missing `std::fmt::Debug` implementations.

When tracing/logging/debugging a program it is common to debug print inputs and outputs of function, to do this generally dependencies need to offer `std::fmt::Debug` implementations.

I won't repeat what is written under [`missing_debug_implementations`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#missing-debug-implementations) which gives some more explanation.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
