### PR TITLE
Update SyscallReturnCode to support types other than i32.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Upcoming Release
+- Updated `SyscallReturnCode` to accept any signed integer type.
+
 ## v0.11.1
 
 ### Changed


### PR DESCRIPTION
### Summary of the PR

Currently, `SyscallReturnCode` is limited to system call return values of type `i32`. However, not all system calls return 32-bit integer values. For example, the [`read` system call](https://man7.org/linux/man-pages/man2/read.2.html) returns an `ssize_t` type, which will map to a 64-bit integer on 64-bit systems.

This PR updates `SyscallReturnCode` to be a generic type that can contain any signed integer value, so it can be used with other integer types. Since existing code may not specify generic type values, I set the type parameter to default to the existing type of `c_int` to try and preserve compatibility.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
