### PR TITLE
Build docs.rs documentation with features enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Upcoming version
+
+### Changed
+- Added all features to the generated docs.rs documentation.
+
 ## v0.11.2
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ keywords = ["utils"]
 edition = "2021"
 license = "BSD-3-Clause"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 with-serde = ["serde", "serde_derive"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! [rust-vmm](https://github.com/rust-vmm/community) components.
 
 #![deny(missing_docs, missing_debug_implementations)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux;


### PR DESCRIPTION
### Summary of the PR

The current documentation build in docs.rs does not include any crate features (at the moment just `with-serde`), which might lead to users of the crate not being aware of their existence.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- `N/A` All added/changed functionality has a corresponding unit/integration
  test.
- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- `N/A` Any newly added `unsafe` code is properly documented.
