### PR TITLE
fix: make ioctl macro expand hygienically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Changed
 - Added all features to the generated docs.rs documentation.
 
+### Fixed
+- Fixed `ioctl_io*_nr` macros expanding unhygenically, requiring for example the
+  import of `ioctl_ioc_nr!` when using `ioctl_iow_nr!`.
+
 ## v0.11.2
 
 ### Changed

--- a/src/linux/ioctl.rs
+++ b/src/linux/ioctl.rs
@@ -75,10 +75,10 @@ macro_rules! ioctl_ioc_nr {
 #[macro_export]
 macro_rules! ioctl_io_nr {
     ($name:ident, $ty:expr, $nr:expr) => {
-        ioctl_ioc_nr!($name, $crate::ioctl::_IOC_NONE, $ty, $nr, 0);
+        $crate::ioctl_ioc_nr!($name, $crate::ioctl::_IOC_NONE, $ty, $nr, 0);
     };
     ($name:ident, $ty:expr, $nr:expr, $($v:ident),+) => {
-        ioctl_ioc_nr!($name, $crate::ioctl::_IOC_NONE, $ty, $nr, 0, $($v),+);
+        $crate::ioctl_ioc_nr!($name, $crate::ioctl::_IOC_NONE, $ty, $nr, 0, $($v),+);
     };
 }
 
@@ -92,7 +92,7 @@ macro_rules! ioctl_io_nr {
 #[macro_export]
 macro_rules! ioctl_ior_nr {
     ($name:ident, $ty:expr, $nr:expr, $size:ty) => {
-        ioctl_ioc_nr!(
+        $crate::ioctl_ioc_nr!(
             $name,
             $crate::ioctl::_IOC_READ,
             $ty,
@@ -101,7 +101,7 @@ macro_rules! ioctl_ior_nr {
         );
     };
     ($name:ident, $ty:expr, $nr:expr, $size:ty, $($v:ident),+) => {
-        ioctl_ioc_nr!(
+        $crate::ioctl_ioc_nr!(
             $name,
             $crate::ioctl::_IOC_READ,
             $ty,
@@ -122,7 +122,7 @@ macro_rules! ioctl_ior_nr {
 #[macro_export]
 macro_rules! ioctl_iow_nr {
     ($name:ident, $ty:expr, $nr:expr, $size:ty) => {
-        ioctl_ioc_nr!(
+        $crate::ioctl_ioc_nr!(
             $name,
             $crate::ioctl::_IOC_WRITE,
             $ty,
@@ -131,7 +131,7 @@ macro_rules! ioctl_iow_nr {
         );
     };
     ($name:ident, $ty:expr, $nr:expr, $size:ty, $($v:ident),+) => {
-        ioctl_ioc_nr!(
+        $crate::ioctl_ioc_nr!(
             $name,
             $crate::ioctl::_IOC_WRITE,
             $ty,
@@ -152,7 +152,7 @@ macro_rules! ioctl_iow_nr {
 #[macro_export]
 macro_rules! ioctl_iowr_nr {
     ($name:ident, $ty:expr, $nr:expr, $size:ty) => {
-        ioctl_ioc_nr!(
+        $crate::ioctl_ioc_nr!(
             $name,
             $crate::ioctl::_IOC_READ | $crate::ioctl::_IOC_WRITE,
             $ty,
@@ -161,7 +161,7 @@ macro_rules! ioctl_iowr_nr {
         );
     };
     ($name:ident, $ty:expr, $nr:expr, $size:ty, $($v:ident),+) => {
-        ioctl_ioc_nr!(
+        $crate::ioctl_ioc_nr!(
             $name,
             $crate::ioctl::_IOC_READ | $crate::ioctl::_IOC_WRITE,
             $ty,


### PR DESCRIPTION
### Summary of the PR

The `ioctl_io*_nr` macros expand to blocks that again contain macros. However, when doing this, the expanded code did not use `$crate`, meaning those submacros had to be in-scope at the call site. This could cause surpising compilation failures if macros were not imported, but rather referred to by their full name (e.g.
`vmm-sys-utils::ioctls::ioctl_iow_nr!`).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
