### PR TITLE
Make `as_mut_fam_struct()` public and unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.12.1
+
+### Changed
+- [[#215](https://github.com/rust-vmm/vmm-sys-util/pull/215)]: Make
+  `as_mut_fam_struct()` public and unsafe to let users modify fields of the
+  header other than the length.
+
 ## v0.12.0
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmm-sys-util"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Intel Virtualization Team <vmm-maintainers@intel.com>"]
 description = "A system utility set"
 repository = "https://github.com/rust-vmm/vmm-sys-util"


### PR DESCRIPTION
### Summary of the PR

We previously made as_mut_fam_struct() of FamStructWrapper private so
that we avoid that users modify the length of the header under our feet.
However, this disallows callers to modify other parts of the header
(which is totally safe to do).

Make as_mut_fam_struct() public again, but also mark it as unsafe,
asking users to guarantee that they will not change the length stored
within the header directly, via the mutable reference.

Also, prepare for release v0.12.1

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
