### PR TITLE
Make `Debug` impl for `FamStructWrapper` print contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Upcoming
+
+### Changed
+
+- [[#228](https://github.com/rust-vmm/vmm-sys-util/pull/228)]: Make `Debug` impl for
+  `FamStructWrapper<T>` print out contents of the flexible array member. This causes
+  `Debug` to only be implemented if `T::Entry: Debug`.
+
 ## v0.12.1
 
 ### Changed

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -21,6 +21,7 @@ use serde::de::{self, Deserialize, Deserializer, SeqAccess, Visitor};
 #[cfg(feature = "with-serde")]
 use serde::{ser::SerializeTuple, Serialize, Serializer};
 use std::fmt;
+use std::fmt::{Debug, Formatter};
 #[cfg(feature = "with-serde")]
 use std::marker::PhantomData;
 use std::mem::{self, size_of};
@@ -160,7 +161,6 @@ pub unsafe trait FamStruct {
 /// A wrapper for [`FamStruct`](trait.FamStruct.html).
 ///
 /// It helps in treating a [`FamStruct`](trait.FamStruct.html) similarly to an actual `Vec`.
-#[derive(Debug)]
 pub struct FamStructWrapper<T: Default + FamStruct> {
     // This variable holds the FamStruct structure. We use a `Vec<T>` to make the allocation
     // large enough while still being aligned for `T`. Only the first element of `Vec<T>`
@@ -169,6 +169,19 @@ pub struct FamStructWrapper<T: Default + FamStruct> {
     // be careful to convert the desired capacity of the `FamStructWrapper`
     // from `FamStruct::Entry` to `T` when reserving or releasing memory.
     mem_allocator: Vec<T>,
+}
+
+impl<T> Debug for FamStructWrapper<T>
+where
+    T: Default + FamStruct + Debug,
+    T::Entry: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FamStructWrapper")
+            .field("fam_struct", &self.as_fam_struct_ref())
+            .field("entries", &self.as_fam_struct_ref().as_slice())
+            .finish()
+    }
 }
 
 impl<T: Default + FamStruct> FamStructWrapper<T> {


### PR DESCRIPTION
Instead of re-interpreting the entire flexible array member contents as `T`, and then printing garbage, actually print out the FAM header, and then the _entries_ of the array.

Tightens the bound on the `Debug` implementation to require `T::Entry: Debug` (as opposed to just `T: Debug`).

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
