### PR TITLE
Use portable-atomic when AtomicU64 is not available.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ libc = "0.2.39"
 serde = { version = "1.0.27", optional = true }
 serde_derive = { version = "1.0.27", optional = true }
 
+[target.'cfg(not(target_has_atomic = "u64"))'.dependencies]
+portable-atomic = "1"
+
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 bitflags = "1.0"
 

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -757,7 +757,7 @@ mod tests {
     fn test_invalid_type_conversion() {
         let mut adapter = MockFamStructWrapperU8::new(10).unwrap();
         assert!(matches!(
-            adapter.set_len(0xffff_ffff_ffff_ff00),
+            adapter.set_len(usize::MAX & !0xff),
             Err(Error::SizeLimitExceeded)
         ));
     }

--- a/src/linux/sock_ctrl_msg.rs
+++ b/src/linux/sock_ctrl_msg.rs
@@ -479,15 +479,15 @@ mod tests {
         if size_of::<RawFd>() == 4 {
             assert_eq!(
                 CMSG_SPACE!(2 * size_of::<RawFd>()),
-                size_of::<cmsghdr>() + size_of::<c_long>()
+                size_of::<cmsghdr>() + size_of::<c_long>() * 2
             );
             assert_eq!(
                 CMSG_SPACE!(3 * size_of::<RawFd>()),
-                size_of::<cmsghdr>() + size_of::<c_long>() * 2
+                size_of::<cmsghdr>() + size_of::<c_long>() * 3
             );
             assert_eq!(
                 CMSG_SPACE!(4 * size_of::<RawFd>()),
-                size_of::<cmsghdr>() + size_of::<c_long>() * 2
+                size_of::<cmsghdr>() + size_of::<c_long>() * 4
             );
         } else if size_of::<RawFd>() == 8 {
             assert_eq!(

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -11,7 +11,12 @@
 //! of these components can choose what metrics they’re interested in and also
 //! can add their own custom metrics without the need to maintain forks.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 
 /// Abstraction over the common metric operations.
 ///
@@ -63,8 +68,12 @@ impl Metric for AtomicU64 {
 mod tests {
     use crate::metric::Metric;
 
+    #[cfg(target_has_atomic = "64")]
     use std::sync::atomic::AtomicU64;
     use std::sync::Arc;
+
+    #[cfg(not(target_has_atomic = "64"))]
+    use portable_atomic::AtomicU64;
 
     struct Dog<T: DogEvents> {
         metrics: T,


### PR DESCRIPTION
### Summary of the PR

Use portable-atomic when AtomicU64 is not available.
Fixes #187

I do not know if AtomicU64 is required, or why other atomic types don't implement Metric.
If it is not required, an alternate change is to use the more portable AtomicUsize.

It is unclear if the changes to test `linux::sock_ctrl_msg::tests::buffer_len`are appropriate since I don't use this crate.

All tests pass in my 32-bit OS except the doc-tests `linux::ioctl::ioctl` and `linux::ioctl::ioctl_with_val`.
These failures are expected because I don't have `/dev/kvm`.

I do not know what should go into the changelog so I left it unchanged.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
