### PR TITLE
fix: remove unsound impl From<Vec<T>> for FamStructWrapper<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ implementation is faster than div_ceil way and more robust.
   `FamStructWrapper<T>` print out contents of the flexible array member. This causes
   `Debug` to only be implemented if `T::Entry: Debug`.
 
+### Removed
+- [[#235](https://github.com/rust-vmm/vmm-sys-util/pull/235)]: Removed `impl
+  From<Vec<T>> for FamStructWrapper<T>`, as this was unsound.
+
 ## v0.12.1
 
 ### Changed

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -286,6 +286,9 @@ impl<T: Default + FamStruct> FamStructWrapper<T> {
     /// This function is unsafe because the caller needs to ensure that the raw content is
     /// correctly layed out.
     pub unsafe fn from_raw(content: Vec<T>) -> Self {
+        debug_assert_ne!(content.len(), 0);
+        debug_assert!(content[0].len() <= Self::fam_len(content.len()));
+
         FamStructWrapper {
             mem_allocator: content,
         }

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -525,12 +525,6 @@ impl<T: Default + FamStruct> Clone for FamStructWrapper<T> {
     }
 }
 
-impl<T: Default + FamStruct> From<Vec<T>> for FamStructWrapper<T> {
-    fn from(vec: Vec<T>) -> Self {
-        FamStructWrapper { mem_allocator: vec }
-    }
-}
-
 #[cfg(feature = "with-serde")]
 impl<T: Default + FamStruct + Serialize> Serialize for FamStructWrapper<T>
 where


### PR DESCRIPTION
The function was implemented exactly like the unsafe
`FamStructWrapper::from_raw`, without nothing preventing unsound usage
(e.g. passing in a Vec of length/capacity 1, but where the contained
element indicated a flexible array member of length > 0, which would
then later cause functions such as as_slice() to return a slice
referencing out-of-bounds memory).

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
