### PR TITLE
chore: enable riscv64 CI

### DIFF
--- a/.platform
+++ b/.platform
@@ -1,0 +1,3 @@
+x86_64
+aarch64
+riscv64

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ with files, event file descriptors, ioctls and others.
 **Platforms**:
 - x86_64
 - aarch64
+- riscv64
 
 **Operating Systems**:
 - Linux


### PR DESCRIPTION
This crate is a dependency of multiple other rust-vmm crates that already have riscv64 support enabled, so really we should be running riscv64 stuff in CI here too.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
