### PR TITLE
fam: Remove `PartialEq` trait constraint on `Entry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Upcoming
 
+### Added
+
+- [[#240](https://github.com/rust-vmm/vmm-sys-util/pull/240)]: Remove
+`PartialEq` trait constraint on `Entry` in FAM module.
+
 ## v0.13.0
 
 ### Added

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -126,7 +126,7 @@ impl fmt::Display for Error {
 #[allow(clippy::len_without_is_empty)]
 pub unsafe trait FamStruct {
     /// The type of the FAM entries
-    type Entry: PartialEq + Copy;
+    type Entry: Copy;
 
     /// Get the FAM length
     ///
@@ -505,7 +505,10 @@ impl<T: Default + FamStruct> FamStructWrapper<T> {
     }
 }
 
-impl<T: Default + FamStruct + PartialEq> PartialEq for FamStructWrapper<T> {
+impl<T: Default + FamStruct + PartialEq> PartialEq for FamStructWrapper<T>
+where
+    T::Entry: PartialEq,
+{
     fn eq(&self, other: &FamStructWrapper<T>) -> bool {
         self.as_fam_struct_ref() == other.as_fam_struct_ref() && self.as_slice() == other.as_slice()
     }


### PR DESCRIPTION
### Summary of the PR

Remove `PartialEq` trait constraint on `Entry`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
