### PR TITLE
Implement EventNotifier/EventConsumer as a generic event notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 -[[#245](https://github.com/rust-vmm/vmm-sys-util/pull/245)]: Make sock_ctrl_msg support unix.
 
+### Added
+
+- [[#244](https://github.com/rust-vmm/vmm-sys-util/pull/244)]: 
+  - Impl `IntoRawFd` for `linux::eventfd::EventFd`.
+  - Use `File::try_clone` to replace the original implementation of `EventFd::try_clone`.
+  Some flags can now be propagated, like `CLOEXEC`.
+  - Add `EventNotifier` and `EventConsumer` as a generic event notification 
+
+
 ## v0.14.0
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,6 @@ with-serde = ["serde", "serde_derive"]
 libc = "0.2.127"
 serde = { version = "1.0.27", optional = true }
 serde_derive = { version = "1.0.27", optional = true }
-
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 bitflags = "1.0"
 
 [dev-dependencies]

--- a/src/linux/eventfd.rs
+++ b/src/linux/eventfd.rs
@@ -8,6 +8,7 @@
 //! [`eventfd`](http://man7.org/linux/man-pages/man2/eventfd.2.html).
 
 use std::fs::File;
+use std::os::fd::IntoRawFd;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::{io, mem, result};
 
@@ -167,6 +168,12 @@ impl FromRawFd for EventFd {
         EventFd {
             eventfd: File::from_raw_fd(fd),
         }
+    }
+}
+
+impl IntoRawFd for EventFd {
+    fn into_raw_fd(self) -> RawFd {
+        self.eventfd.into_raw_fd()
     }
 }
 

--- a/src/unix/event.rs
+++ b/src/unix/event.rs
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//! This module provides a platform-independent interface for event notification,
+//! enabling support across multiple operating systems.
+//!
+//! Internally, it uses a file descriptor that can be backed by various mechanisms
+//! such as `eventfd`, `pipe`, or other OS-specific primitives.
+
+use std::io::{Read, Write};
+use std::os::fd::RawFd;
+use std::{
+    fs::File,
+    io,
+    os::fd::{AsRawFd, FromRawFd, IntoRawFd},
+    result::Result,
+};
+
+bitflags::bitflags! {
+    /// EventFlag
+    /// This enum is used to define flags for the event notifier and consumer.
+    pub struct EventFlag: u8 {
+        /// Non-blocking flag
+        const NONBLOCK = 1 << 0;
+        /// Close-on-exec flag
+        const CLOEXEC = 1 << 1;
+    }
+}
+
+/// EventNotifier
+/// This is a generic event notifier that can be used with eventfd or pipefd.
+/// It allows writing a value to the file descriptor to notify an event.
+///
+/// # Examples
+///
+/// ```
+/// use std::os::fd::FromRawFd;
+/// use std::os::unix::io::IntoRawFd;
+/// use vmm_sys_util::event::EventNotifier;
+/// let (_, writer) = std::io::pipe().expect("Failed to create pipe");
+/// let notifier = unsafe { EventNotifier::from_raw_fd(writer.into_raw_fd()) };
+/// ```
+#[derive(Debug)]
+pub struct EventNotifier {
+    fd: File,
+}
+
+impl EventNotifier {
+    /// Write a value to the EventNotifier's fd
+    /// Writing 1 to fd is for compatibility with Eventfd
+    pub fn notify(&self) -> Result<(), io::Error> {
+        let v = 1u64;
+        (&self.fd).write_all(&v.to_ne_bytes())
+    }
+
+    /// Clone this EventNotifier.
+    pub fn try_clone(&self) -> Result<EventNotifier, io::Error> {
+        Ok(EventNotifier {
+            fd: self.fd.try_clone()?,
+        })
+    }
+}
+
+impl AsRawFd for EventNotifier {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd.as_raw_fd()
+    }
+}
+
+impl FromRawFd for EventNotifier {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        EventNotifier {
+            fd: File::from_raw_fd(fd),
+        }
+    }
+}
+
+impl IntoRawFd for EventNotifier {
+    fn into_raw_fd(self) -> RawFd {
+        self.fd.into_raw_fd()
+    }
+}
+
+/// EventConsumer
+/// This is a generic event consumer that can be used with eventfd or pipefd.
+/// It allows reading a value from the file descriptor to consume an event.
+///
+/// # Examples
+///
+/// ```
+/// use std::os::fd::FromRawFd;
+/// use std::os::unix::io::IntoRawFd;
+/// use vmm_sys_util::event::EventConsumer;
+/// let (reader, _) = std::io::pipe().expect("Failed to create pipe");
+/// let consumer = unsafe { EventConsumer::from_raw_fd(reader.into_raw_fd()) };
+/// ```
+#[derive(Debug)]
+pub struct EventConsumer {
+    fd: File,
+}
+
+impl EventConsumer {
+    /// Read a value from the EventConsumer.
+    pub fn consume(&self) -> Result<(), io::Error> {
+        let mut buf = [0u8; size_of::<u64>()];
+        (&self.fd).read_exact(buf.as_mut_slice()).map(|_| Ok(()))?
+    }
+
+    /// Clone this EventConsumer.
+    pub fn try_clone(&self) -> Result<EventConsumer, io::Error> {
+        Ok(EventConsumer {
+            fd: self.fd.try_clone()?,
+        })
+    }
+}
+
+impl AsRawFd for EventConsumer {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd.as_raw_fd()
+    }
+}
+
+impl FromRawFd for EventConsumer {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        EventConsumer {
+            fd: File::from_raw_fd(fd),
+        }
+    }
+}
+
+impl IntoRawFd for EventConsumer {
+    fn into_raw_fd(self) -> RawFd {
+        self.fd.into_raw_fd()
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+unsafe fn fcntl_setfl(fd: RawFd, flag: i32) -> Result<(), io::Error> {
+    let flags = libc::fcntl(fd, libc::F_GETFL);
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let ret = libc::fcntl(fd, libc::F_SETFL, flags | flag);
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+unsafe fn fcntl_setfd(fd: RawFd, flag: i32) -> Result<(), io::Error> {
+    let flags = libc::fcntl(fd, libc::F_GETFD);
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let ret = libc::fcntl(fd, libc::F_SETFD, flags | flag);
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Create a new EventNotifier and EventConsumer using a pipe.
+///
+/// # Arguments
+///
+/// * `flags` - Flags to set on the file descriptor, such as `EventFlag::NONBLOCK` or `EventFlag::CLOEXEC`.
+///
+/// # Examples
+///
+/// ```
+/// use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
+/// let (consumer, notifier) = new_event_consumer_and_notifier(EventFlag::NONBLOCK)
+///     .expect("Failed to create notifier and consumer");
+/// notifier.notify().unwrap();
+/// assert!(consumer.consume().is_ok());
+/// ```
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+pub fn new_event_consumer_and_notifier(
+    flags: EventFlag,
+) -> Result<(EventConsumer, EventNotifier), io::Error> {
+    // Use a pipe for non-Linux platforms.
+    let mut fds: [RawFd; 2] = [-1, -1];
+    // SAFETY: This is safe because pipe merely allocated a read fd and a write fd
+    // for our process and we handle the error case.
+    let ret = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+    let consumer = unsafe { EventConsumer::from_raw_fd(fds[0]) };
+    // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+    let notifier = unsafe { EventNotifier::from_raw_fd(fds[1]) };
+    if flags.contains(EventFlag::NONBLOCK) {
+        // SAFETY: We ensure that the passed fd is valid and check the return value of all operations.
+        // If an exception is thrown, the fds will be closed.
+        unsafe {
+            fcntl_setfl(consumer.as_raw_fd(), libc::O_NONBLOCK)?;
+            fcntl_setfl(notifier.as_raw_fd(), libc::O_NONBLOCK)?;
+        }
+    }
+    if flags.contains(EventFlag::CLOEXEC) {
+        // SAFETY: We ensure that the passed fd is valid and check the return value of all operations.
+        // If an exception is thrown, the fds will be closed.
+        unsafe {
+            fcntl_setfd(consumer.as_raw_fd(), libc::FD_CLOEXEC)?;
+            fcntl_setfd(notifier.as_raw_fd(), libc::FD_CLOEXEC)?;
+        }
+    }
+    Ok((consumer, notifier))
+}
+
+/// Create a new EventNotifier and EventConsumer using eventfd.
+///
+/// # Arguments
+///
+/// * `flags` - Flags to set on the file descriptor, such as `EventFlag::NONBLOCK` or `EventFlag::CLOEXEC`.
+///
+/// # Examples
+///
+/// ```
+/// use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
+/// let (consumer, notifier) = new_event_consumer_and_notifier(EventFlag::NONBLOCK)
+///     .expect("Failed to create consumer and notifier");
+/// notifier.notify().unwrap();
+/// assert!(consumer.consume().is_ok());
+/// ```
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn new_event_consumer_and_notifier(
+    flags: EventFlag,
+) -> Result<(EventConsumer, EventNotifier), io::Error> {
+    let mut efd_flags = 0;
+    if flags.contains(EventFlag::NONBLOCK) {
+        efd_flags |= libc::EFD_NONBLOCK;
+    }
+    if flags.contains(EventFlag::CLOEXEC) {
+        efd_flags |= libc::EFD_CLOEXEC;
+    }
+    let eventfd = crate::linux::eventfd::EventFd::new(efd_flags)?;
+    let eventfd_clone = eventfd.try_clone()?;
+    // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+    let consumer = unsafe { EventConsumer::from_raw_fd(eventfd.into_raw_fd()) };
+    // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+    let notifier = unsafe { EventNotifier::from_raw_fd(eventfd_clone.into_raw_fd()) };
+    Ok((consumer, notifier))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{io::pipe, os::fd::IntoRawFd};
+
+    #[test]
+    fn test_notify_and_consume() {
+        let (reader, writer) = pipe().expect("Failed to create pipe");
+        // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+        let notifier = unsafe { EventNotifier::from_raw_fd(writer.into_raw_fd()) };
+        // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+        let consumer = unsafe { EventConsumer::from_raw_fd(reader.into_raw_fd()) };
+
+        notifier.notify().unwrap();
+        assert!(consumer.consume().is_ok());
+    }
+
+    #[test]
+    fn test_clone() {
+        let (reader, writer) = pipe().expect("Failed to create pipe");
+        // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+        let notifier = unsafe { EventNotifier::from_raw_fd(writer.into_raw_fd()) };
+        // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+        let consumer = unsafe { EventConsumer::from_raw_fd(reader.into_raw_fd()) };
+
+        let cloned_notifier = notifier.try_clone().expect("Failed to clone notifier");
+        let cloned_consumer = consumer.try_clone().expect("Failed to clone consumer");
+
+        cloned_notifier.notify().unwrap();
+        assert!(cloned_consumer.consume().is_ok());
+    }
+
+    #[test]
+    fn test_new_event_notifier_and_consumer() {
+        let (consumer, notifier) = new_event_consumer_and_notifier(EventFlag::empty())
+            .expect("Failed to create notifier and consumer");
+        notifier.notify().unwrap();
+        assert!(consumer.consume().is_ok());
+    }
+
+    #[test]
+    fn test_nonblock() {
+        let (consumer, _notifier) = new_event_consumer_and_notifier(EventFlag::NONBLOCK)
+            .expect("Failed to create notifier and consumer");
+        let r = consumer.consume();
+        match r {
+            Err(ref inner) if inner.kind() == io::ErrorKind::WouldBlock => (),
+            _ => panic!("Unexpected"),
+        }
+    }
+
+    #[test]
+    fn test_cloexec() {
+        let (consumer, notifier) = new_event_consumer_and_notifier(EventFlag::CLOEXEC)
+            .expect("Failed to create notifier and consumer");
+        // SAFETY: This is safe because we check the fd and the return value are valid.
+        let flags = unsafe { libc::fcntl(consumer.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags >= 0 && flags & libc::FD_CLOEXEC == 1);
+        // SAFETY: This is safe because we check the fd and the return value are valid.
+        let flags = unsafe { libc::fcntl(notifier.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags >= 0 && flags & libc::FD_CLOEXEC == 1);
+        let consumer_cloned = consumer.try_clone().expect("Failed to clone consumer");
+        // SAFETY: This is safe because we check the fd and the return value are valid.
+        let flags = unsafe { libc::fcntl(consumer_cloned.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags >= 0 && flags & libc::FD_CLOEXEC == 1);
+        let notifier_cloned = notifier.try_clone().expect("Failed to clone notifier");
+        // SAFETY: This is safe because we check the fd and the return value are valid.
+        let flags = unsafe { libc::fcntl(notifier_cloned.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags >= 0 && flags & libc::FD_CLOEXEC == 1);
+    }
+}

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 rust-vmm Authors or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: BSD-3-Clause
+pub mod event;
 pub mod file_traits;
 pub mod sock_ctrl_msg;
 pub mod tempdir;


### PR DESCRIPTION
### Summary of the PR

Introduce an abstract event notification in order to support multiple platforms. EventNotifier is used to send a notification, and EventConsumer is used to receive a notification. The fd used in EventNotifier or EventConsumer can be from eventfd, pipefd or others.

They can be used like this: https://github.com/uran0sH/vhost/pull/1
### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ x ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ x ] All added/changed functionality has a corresponding unit/integration
  test.
- [ x ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ x ] Any newly added `unsafe` code is properly documented.
