### PR TITLE
Prepare v0.15.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags: ['v*']  # Triggers when pushing tags starting with 'v'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # environment: release  # Optional: for enhanced security
+    permissions:
+      id-token: write     # Required for OIDC token exchange
+    steps:
+    - uses: actions/checkout@v4
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## Upcoming
 
--[[#245](https://github.com/rust-vmm/vmm-sys-util/pull/245)]: Make sock_ctrl_msg support unix.
+## v0.15.0
 
 ### Added
 
+- [[#245](https://github.com/rust-vmm/vmm-sys-util/pull/245)]: Make sock_ctrl_msg support non-linux unix platforms.
 - [[#244](https://github.com/rust-vmm/vmm-sys-util/pull/244)]: 
   - Impl `IntoRawFd` for `linux::eventfd::EventFd`.
   - Use `File::try_clone` to replace the original implementation of `EventFd::try_clone`.
   Some flags can now be propagated, like `CLOEXEC`.
   - Add `EventNotifier` and `EventConsumer` as a generic event notification 
-
 
 ## v0.14.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmm-sys-util"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Intel Virtualization Team <vmm-maintainers@intel.com>"]
 description = "A system utility set"
 repository = "https://github.com/rust-vmm/vmm-sys-util"


### PR DESCRIPTION
### Summary of the PR

This release mainly improve support for macOS/BSD systems for vhost-user supporting sock_ctrl_msg on POSIX and adding a cross platform event notification that uses EventFd when available or pipe().

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
