### PR TITLE
timerfd: support TFD_NONBLOCK flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+### Added
+
+- [[#254](https://github.com/rust-vmm/vmm-sys-util/pull/254)]: Support `TFD_NONBLOCK` for `timerfd::TimerFd`.
+
 ## v0.15.0
 
 ### Added


### PR DESCRIPTION
Currently, the timerfd module does not allow specifying different flags for the created timers. Add support for this via a new method, `TimerFd::new_with_flags`.

This will allow firecracker to use the implementation from this crate, instead of the dedicated `timerfd` crate (which pulls in the rustix crate, of which we have like 3 different versions in our dependency tree right now).

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
