### PR TITLE
chore: rename `with-serde` feature to `serde`

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+[advisories]
+ignore = [
+    # bincode is an unmaintained dependency introduced by versionize.
+    # Issue reported at https://github.com/firecracker-microvm/versionize/issues/63
+    # While waiting for a solution, let's ignore it since it's just unmaintained.
+    "RUSTSEC-2025-0141",
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [[#254](https://github.com/rust-vmm/vmm-sys-util/pull/254)]: Support `TFD_NONBLOCK` for `timerfd::TimerFd`.
 
+### Changed
+
+- [[#220](https://github.com/rust-vmm/vmm-sys-util/issues/220)]: Renamed `with-serde` feature to `serde` to follow Rust API naming guidelines. The old `with-serde` name is kept as a deprecated alias for backward compatibility but will be removed in a future release.
+
 ## v0.15.0
 
 ### Added
@@ -161,7 +165,7 @@ function for constructing an empty FamStructWrapper with a given header.
 # v0.5.0
 
 * Added conditionally compiled `serde` compatibility to `FamStructWrapper`,
-  gated by the `with-serde` feature.
+  gated by the `serde` feature.
 * Implemented `Into<std::io::Error` for `errno::Error`.
 * Added a wrapper over `libc::epoll` used for basic epoll operations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,7 +165,7 @@ function for constructing an empty FamStructWrapper with a given header.
 # v0.5.0
 
 * Added conditionally compiled `serde` compatibility to `FamStructWrapper`,
-  gated by the `serde` feature.
+  gated by the `with-serde` feature.
 * Implemented `Into<std::io::Error` for `errno::Error`.
 * Added a wrapper over `libc::epoll` used for basic epoll operations.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-with-serde = ["serde", "serde_derive"]
+serde = ["dep:serde", "serde_derive"]
+with-serde = ["serde"] # Deprecated alias, use `serde` instead
 
 [dependencies]
 libc = "0.2.127"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if std::env::var("CARGO_FEATURE_WITH_SERDE").is_ok() {
+        println!("cargo:warning=The `with-serde` feature has been renamed to `serde`. Please update your Cargo.toml to use `serde` instead. The `with-serde` alias will be removed in a future release.");
+    }
+}

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -16,13 +16,13 @@
 //!
 //! For example the KVM API has many structures of this kind.
 
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 use serde::de::{self, Deserialize, Deserializer, SeqAccess, Visitor};
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 use serde::{ser::SerializeTuple, Serialize, Serializer};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 use std::marker::PhantomData;
 use std::mem::{self, size_of};
 
@@ -548,7 +548,7 @@ impl<T: Default + FamStruct> Clone for FamStructWrapper<T> {
     }
 }
 
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 impl<T: Default + FamStruct + Serialize> Serialize for FamStructWrapper<T>
 where
     <T as FamStruct>::Entry: serde::Serialize,
@@ -564,7 +564,7 @@ where
     }
 }
 
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 impl<'de, T: Default + FamStruct + Deserialize<'de>> Deserialize<'de> for FamStructWrapper<T>
 where
     <T as FamStruct>::Entry: std::marker::Copy + serde::Deserialize<'de>,
@@ -658,7 +658,7 @@ macro_rules! generate_fam_struct_impl {
 mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
 
-    #[cfg(feature = "with-serde")]
+    #[cfg(feature = "serde")]
     use serde_derive::{Deserialize, Serialize};
 
     use super::*;
@@ -691,7 +691,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "with-serde")]
+    #[cfg(feature = "serde")]
     impl<T> Serialize for __IncompleteArrayField<T> {
         fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
         where
@@ -701,7 +701,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "with-serde")]
+    #[cfg(feature = "serde")]
     impl<'de, T> Deserialize<'de> for __IncompleteArrayField<T> {
         fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
         where
@@ -1027,17 +1027,17 @@ mod tests {
         assert_eq!(data[0].padding, 5);
     }
 
-    #[cfg(feature = "with-serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_ser_deser() {
         #[repr(C)]
         #[derive(Default, PartialEq)]
-        #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+        #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
         struct Message {
             pub len: u32,
             pub padding: u32,
             pub value: u32,
-            #[cfg_attr(feature = "with-serde", serde(skip))]
+            #[cfg_attr(feature = "serde", serde(skip))]
             pub entries: __IncompleteArrayField<u32>,
         }
 
@@ -1075,12 +1075,12 @@ mod tests {
 
         #[repr(C)]
         #[derive(Default)]
-        #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+        #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
         struct Message2 {
             pub len: u32,
             pub padding: u32,
             pub value: u32,
-            #[cfg_attr(feature = "with-serde", serde(skip))]
+            #[cfg_attr(feature = "serde", serde(skip))]
             pub entries: __IncompleteArrayField<u32>,
         }
 
@@ -1160,7 +1160,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "with-serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_bad_deserialize() {
         #[repr(C)]


### PR DESCRIPTION
Rename the feature to follow Rust API naming guidelines which recommend avoiding placeholder words like "with" in feature names.

The old `with-serde` name is kept as a deprecated alias with a build-time warning to help downstream users migrate.

Closes rust-vmm/rust-vmm#10

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
