### PR TITLE
docs: hide boilerplate from documentation examples

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -21,8 +21,7 @@
 /// # Example
 ///
 /// ```rust
-/// use vmm_sys_util::align_downwards;
-///
+/// # use vmm_sys_util::align_downwards;
 /// let addr: usize = 10;
 /// let alignment: usize = 4; // Must be a power of two
 /// let aligned = align_downwards!(addr, alignment);
@@ -56,8 +55,7 @@ macro_rules! align_downwards {
 /// # Example
 ///
 /// ```rust
-/// use vmm_sys_util::align_upwards;
-///
+/// # use vmm_sys_util::align_upwards;
 /// let addr: usize = 10;
 /// let alignment: usize = 4; // Must be a power of two
 /// let aligned = align_upwards!(addr, alignment);

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -37,8 +37,6 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// # extern crate libc;
-    /// # extern crate vmm_sys_util;
     /// # use libc;
     /// # use vmm_sys_util::errno::Error;
     /// let err = Error::new(libc::EIO);
@@ -57,8 +55,6 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// # extern crate libc;
-    /// # extern crate vmm_sys_util;
     /// # use libc;
     /// # use std::fs::File;
     /// # use std::io::{self, Read};
@@ -87,7 +83,6 @@ impl Error {
     ///
     /// # Examples
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use vmm_sys_util::errno::Error;
     /// let err = Error::new(13);
     /// assert_eq!(err.errno(), 13);

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -38,11 +38,9 @@ impl Error {
     ///
     /// ```
     /// # extern crate libc;
-    /// extern crate vmm_sys_util;
-    /// #
+    /// # extern crate vmm_sys_util;
     /// # use libc;
-    /// use vmm_sys_util::errno::Error;
-    ///
+    /// # use vmm_sys_util::errno::Error;
     /// let err = Error::new(libc::EIO);
     /// ```
     pub fn new(errno: i32) -> Error {
@@ -60,14 +58,12 @@ impl Error {
     ///
     /// ```
     /// # extern crate libc;
-    /// extern crate vmm_sys_util;
-    /// #
+    /// # extern crate vmm_sys_util;
     /// # use libc;
     /// # use std::fs::File;
     /// # use std::io::{self, Read};
     /// # use std::env::temp_dir;
-    /// use vmm_sys_util::errno::Error;
-    /// #
+    /// # use vmm_sys_util::errno::Error;
     /// // Reading from a file without permissions returns an error.
     /// let mut path = temp_dir();
     /// path.push("test");
@@ -91,9 +87,8 @@ impl Error {
     ///
     /// # Examples
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::errno::Error;
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use vmm_sys_util::errno::Error;
     /// let err = Error::new(13);
     /// assert_eq!(err.errno(), 13);
     /// ```

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -59,8 +59,7 @@ impl fmt::Display for Error {
 /// # Example
 ///
 /// ```
-/// use vmm_sys_util::fam::*;
-///
+/// # use vmm_sys_util::fam::*;
 /// #[repr(C)]
 /// #[derive(Default)]
 /// pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);

--- a/src/linux/aio.rs
+++ b/src/linux/aio.rs
@@ -108,8 +108,7 @@ impl IoContext {
     ///
     /// # Examples
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::aio::*;
+    /// # use vmm_sys_util::aio::*;
     /// # use std::fs::File;
     /// # use std::os::unix::io::AsRawFd;
     ///
@@ -181,8 +180,7 @@ impl IoContext {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::aio::*;
+    /// # use vmm_sys_util::aio::*;
     /// # use std::fs::File;
     /// # use std::os::unix::io::AsRawFd;
     ///

--- a/src/linux/epoll.rs
+++ b/src/linux/epoll.rs
@@ -111,7 +111,6 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use vmm_sys_util::epoll::{EpollEvent, EventSet};
     /// let event = EpollEvent::new(EventSet::IN, 2);
     /// ```
@@ -128,7 +127,6 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use vmm_sys_util::epoll::{EpollEvent, EventSet};
     /// let event = EpollEvent::new(EventSet::IN, 2);
     /// assert_eq!(event.events(), 1);
@@ -147,7 +145,6 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use vmm_sys_util::epoll::{EpollEvent, EventSet};
     /// let event = EpollEvent::new(EventSet::IN, 2);
     /// assert_eq!(event.event_set(), EventSet::IN);
@@ -164,7 +161,6 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use vmm_sys_util::epoll::{EpollEvent, EventSet};
     /// let event = EpollEvent::new(EventSet::IN, 2);
     /// assert_eq!(event.data(), 2);
@@ -181,7 +177,6 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use vmm_sys_util::epoll::{EpollEvent, EventSet};
     /// let event = EpollEvent::new(EventSet::IN, 2);
     /// assert_eq!(event.fd(), 2);
@@ -222,7 +217,6 @@ impl Epoll {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use std::os::unix::io::AsRawFd;
     /// # use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
     /// # use vmm_sys_util::eventfd::EventFd;
@@ -273,7 +267,6 @@ impl Epoll {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use std::os::unix::io::AsRawFd;
     /// # use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
     /// # use vmm_sys_util::eventfd::EventFd;

--- a/src/linux/epoll.rs
+++ b/src/linux/epoll.rs
@@ -111,9 +111,8 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use vmm_sys_util::epoll::{EpollEvent, EventSet};
     /// let event = EpollEvent::new(EventSet::IN, 2);
     /// ```
     pub fn new(events: EventSet, data: u64) -> Self {
@@ -129,9 +128,8 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use vmm_sys_util::epoll::{EpollEvent, EventSet};
     /// let event = EpollEvent::new(EventSet::IN, 2);
     /// assert_eq!(event.events(), 1);
     /// ```
@@ -149,9 +147,8 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use vmm_sys_util::epoll::{EpollEvent, EventSet};
     /// let event = EpollEvent::new(EventSet::IN, 2);
     /// assert_eq!(event.event_set(), EventSet::IN);
     /// ```
@@ -167,9 +164,8 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use vmm_sys_util::epoll::{EpollEvent, EventSet};
     /// let event = EpollEvent::new(EventSet::IN, 2);
     /// assert_eq!(event.data(), 2);
     /// ```
@@ -185,9 +181,8 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use vmm_sys_util::epoll::{EpollEvent, EventSet};
     /// let event = EpollEvent::new(EventSet::IN, 2);
     /// assert_eq!(event.fd(), 2);
     /// ```
@@ -227,12 +222,10 @@ impl Epoll {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    ///
-    /// use std::os::unix::io::AsRawFd;
-    /// use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
-    /// use vmm_sys_util::eventfd::EventFd;
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use std::os::unix::io::AsRawFd;
+    /// # use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
+    /// # use vmm_sys_util::eventfd::EventFd;
     /// let epoll = Epoll::new().unwrap();
     /// let event_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
     /// epoll
@@ -280,12 +273,10 @@ impl Epoll {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    ///
-    /// use std::os::unix::io::AsRawFd;
-    /// use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
-    /// use vmm_sys_util::eventfd::EventFd;
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use std::os::unix::io::AsRawFd;
+    /// # use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
+    /// # use vmm_sys_util::eventfd::EventFd;
     /// let epoll = Epoll::new().unwrap();
     /// let event_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();
     ///

--- a/src/linux/eventfd.rs
+++ b/src/linux/eventfd.rs
@@ -34,9 +34,8 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     /// EventFd::new(EFD_NONBLOCK).unwrap();
     /// ```
     pub fn new(flag: i32) -> result::Result<EventFd, io::Error> {
@@ -68,9 +67,8 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
     /// evt.write(55).unwrap();
     /// ```
@@ -87,9 +85,8 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
     /// evt.write(55).unwrap();
     /// assert_eq!(evt.read().unwrap(), 55);
@@ -108,9 +105,8 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
-    ///
+    /// # extern crate vmm_sys_util;
+    /// # use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
     /// let evt_clone = evt.try_clone().unwrap();
     /// evt.write(923).unwrap();

--- a/src/linux/eventfd.rs
+++ b/src/linux/eventfd.rs
@@ -34,7 +34,6 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     /// EventFd::new(EFD_NONBLOCK).unwrap();
     /// ```
@@ -67,7 +66,6 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
     /// evt.write(55).unwrap();
@@ -85,7 +83,6 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
     /// evt.write(55).unwrap();
@@ -105,7 +102,6 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
     /// let evt_clone = evt.try_clone().unwrap();

--- a/src/linux/fallocate.rs
+++ b/src/linux/fallocate.rs
@@ -38,11 +38,10 @@ pub enum FallocateMode {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
 /// # use std::fs::OpenOptions;
 /// # use std::path::PathBuf;
-/// use vmm_sys_util::fallocate::{fallocate, FallocateMode};
-/// use vmm_sys_util::tempdir::TempDir;
+/// # use vmm_sys_util::fallocate::{fallocate, FallocateMode};
+/// # use vmm_sys_util::tempdir::TempDir;
 ///
 /// let tempdir = TempDir::new_with_prefix("/tmp/fallocate_test").unwrap();
 /// let mut path = PathBuf::from(tempdir.as_path());

--- a/src/linux/ioctl.rs
+++ b/src/linux/ioctl.rs
@@ -21,7 +21,7 @@ use std::os::unix::io::AsRawFd;
 /// ```
 /// # use std::os::raw::c_uint;
 /// # use vmm_sys_util::ioctl::{ioctl_expr, _IOC_NONE};
-/// const KVMIO: c_uint = 0xAE;
+/// # const KVMIO: c_uint = 0xAE;
 /// ioctl_expr(_IOC_NONE, KVMIO, 0x01, 0);
 /// ```
 pub const fn ioctl_expr(
@@ -41,9 +41,8 @@ pub const fn ioctl_expr(
 /// ```
 /// # #[macro_use] extern crate vmm_sys_util;
 /// # use std::os::raw::c_uint;
-/// use vmm_sys_util::ioctl::_IOC_NONE;
-///
-/// const KVMIO: c_uint = 0xAE;
+/// # use vmm_sys_util::ioctl::_IOC_NONE;
+/// # const KVMIO: c_uint = 0xAE;
 /// ioctl_ioc_nr!(KVM_CREATE_VM, _IOC_NONE, KVMIO, 0x01, 0);
 /// ```
 #[macro_export]
@@ -69,7 +68,7 @@ macro_rules! ioctl_ioc_nr {
 /// ```
 /// # #[macro_use] extern crate vmm_sys_util;
 /// # use std::os::raw::c_uint;
-/// const KVMIO: c_uint = 0xAE;
+/// # const KVMIO: c_uint = 0xAE;
 /// ioctl_io_nr!(KVM_CREATE_VM, KVMIO, 0x01);
 /// ```
 #[macro_export]
@@ -86,7 +85,7 @@ macro_rules! ioctl_io_nr {
 ///
 /// ```
 /// # #[macro_use] extern crate vmm_sys_util;
-/// const TUNTAP: ::std::os::raw::c_uint = 0x54;
+/// # const TUNTAP: ::std::os::raw::c_uint = 0x54;
 /// ioctl_ior_nr!(TUNGETFEATURES, TUNTAP, 0xcf, ::std::os::raw::c_uint);
 /// ```
 #[macro_export]
@@ -116,7 +115,7 @@ macro_rules! ioctl_ior_nr {
 ///
 /// ```
 /// # #[macro_use] extern crate vmm_sys_util;
-/// const TUNTAP: ::std::os::raw::c_uint = 0x54;
+/// # const TUNTAP: ::std::os::raw::c_uint = 0x54;
 /// ioctl_iow_nr!(TUNSETQUEUE, TUNTAP, 0xd9, ::std::os::raw::c_int);
 /// ```
 #[macro_export]
@@ -146,7 +145,7 @@ macro_rules! ioctl_iow_nr {
 ///
 /// ```
 /// # #[macro_use] extern crate vmm_sys_util;
-/// const VHOST: ::std::os::raw::c_uint = 0xAF;
+/// # const VHOST: ::std::os::raw::c_uint = 0xAF;
 /// ioctl_iowr_nr!(VHOST_GET_VRING_BASE, VHOST, 0x12, ::std::os::raw::c_int);
 /// ```
 #[macro_export]
@@ -229,17 +228,14 @@ type IoctlRequest = c_int;
 /// ```
 /// # extern crate libc;
 /// # #[macro_use] extern crate vmm_sys_util;
-/// #
 /// # use libc::{open, O_CLOEXEC, O_RDWR};
 /// # use std::fs::File;
 /// # use std::os::raw::{c_char, c_uint};
 /// # use std::os::unix::io::FromRawFd;
-/// use vmm_sys_util::ioctl::ioctl;
-///
-/// const KVMIO: c_uint = 0xAE;
-/// const KVM_API_VERSION: u32 = 12;
-/// ioctl_io_nr!(KVM_GET_API_VERSION, KVMIO, 0x00);
-///
+/// # use vmm_sys_util::ioctl::ioctl;
+/// # const KVMIO: c_uint = 0xAE;
+/// # const KVM_API_VERSION: u32 = 12;
+/// # ioctl_io_nr!(KVM_GET_API_VERSION, KVMIO, 0x00);
 /// let open_flags = O_RDWR | O_CLOEXEC;
 /// let kvm_fd = unsafe { open("/dev/kvm\0".as_ptr() as *const c_char, open_flags) };
 ///
@@ -275,12 +271,10 @@ pub unsafe fn ioctl<F: AsRawFd>(fd: &F, req: c_ulong) -> c_int {
 /// # use std::fs::File;
 /// # use std::os::raw::{c_char, c_uint, c_ulong};
 /// # use std::os::unix::io::FromRawFd;
-/// use vmm_sys_util::ioctl::ioctl_with_val;
-///
-/// const KVMIO: c_uint = 0xAE;
-/// const KVM_CAP_USER_MEMORY: u32 = 3;
-/// ioctl_io_nr!(KVM_CHECK_EXTENSION, KVMIO, 0x03);
-///
+/// # use vmm_sys_util::ioctl::ioctl_with_val;
+/// # const KVMIO: c_uint = 0xAE;
+/// # const KVM_CAP_USER_MEMORY: u32 = 3;
+/// # ioctl_io_nr!(KVM_CHECK_EXTENSION, KVMIO, 0x03);
 /// let open_flags = O_RDWR | O_CLOEXEC;
 /// let kvm_fd = unsafe { open("/dev/kvm\0".as_ptr() as *const c_char, open_flags) };
 ///

--- a/src/linux/ioctl.rs
+++ b/src/linux/ioctl.rs
@@ -39,9 +39,9 @@ pub const fn ioctl_expr(
 /// Declare a function that returns an ioctl number.
 ///
 /// ```
-/// # #[macro_use] extern crate vmm_sys_util;
 /// # use std::os::raw::c_uint;
 /// # use vmm_sys_util::ioctl::_IOC_NONE;
+/// # use vmm_sys_util::ioctl_ioc_nr;
 /// # const KVMIO: c_uint = 0xAE;
 /// ioctl_ioc_nr!(KVM_CREATE_VM, _IOC_NONE, KVMIO, 0x01, 0);
 /// ```
@@ -66,8 +66,8 @@ macro_rules! ioctl_ioc_nr {
 /// Declare an ioctl that transfers no data.
 ///
 /// ```
-/// # #[macro_use] extern crate vmm_sys_util;
 /// # use std::os::raw::c_uint;
+/// # use vmm_sys_util::ioctl_io_nr;
 /// # const KVMIO: c_uint = 0xAE;
 /// ioctl_io_nr!(KVM_CREATE_VM, KVMIO, 0x01);
 /// ```
@@ -84,7 +84,7 @@ macro_rules! ioctl_io_nr {
 /// Declare an ioctl that reads data.
 ///
 /// ```
-/// # #[macro_use] extern crate vmm_sys_util;
+/// # use vmm_sys_util::ioctl_ior_nr;
 /// # const TUNTAP: ::std::os::raw::c_uint = 0x54;
 /// ioctl_ior_nr!(TUNGETFEATURES, TUNTAP, 0xcf, ::std::os::raw::c_uint);
 /// ```
@@ -114,7 +114,7 @@ macro_rules! ioctl_ior_nr {
 /// Declare an ioctl that writes data.
 ///
 /// ```
-/// # #[macro_use] extern crate vmm_sys_util;
+/// # use vmm_sys_util::ioctl_iow_nr;
 /// # const TUNTAP: ::std::os::raw::c_uint = 0x54;
 /// ioctl_iow_nr!(TUNSETQUEUE, TUNTAP, 0xd9, ::std::os::raw::c_int);
 /// ```
@@ -144,7 +144,7 @@ macro_rules! ioctl_iow_nr {
 /// Declare an ioctl that reads and writes data.
 ///
 /// ```
-/// # #[macro_use] extern crate vmm_sys_util;
+/// # use vmm_sys_util::ioctl_iowr_nr;
 /// # const VHOST: ::std::os::raw::c_uint = 0xAF;
 /// ioctl_iowr_nr!(VHOST_GET_VRING_BASE, VHOST, 0x12, ::std::os::raw::c_int);
 /// ```
@@ -226,13 +226,12 @@ type IoctlRequest = c_int;
 /// # Examples
 ///
 /// ```
-/// # extern crate libc;
-/// # #[macro_use] extern crate vmm_sys_util;
 /// # use libc::{open, O_CLOEXEC, O_RDWR};
 /// # use std::fs::File;
 /// # use std::os::raw::{c_char, c_uint};
 /// # use std::os::unix::io::FromRawFd;
 /// # use vmm_sys_util::ioctl::ioctl;
+/// # use vmm_sys_util::ioctl_io_nr;
 /// # const KVMIO: c_uint = 0xAE;
 /// # const KVM_API_VERSION: u32 = 12;
 /// # ioctl_io_nr!(KVM_GET_API_VERSION, KVMIO, 0x00);
@@ -265,13 +264,12 @@ pub unsafe fn ioctl<F: AsRawFd>(fd: &F, req: c_ulong) -> c_int {
 /// # Examples
 ///
 /// ```
-/// # extern crate libc;
-/// # #[macro_use] extern crate vmm_sys_util;
 /// # use libc::{open, O_CLOEXEC, O_RDWR};
 /// # use std::fs::File;
 /// # use std::os::raw::{c_char, c_uint, c_ulong};
 /// # use std::os::unix::io::FromRawFd;
 /// # use vmm_sys_util::ioctl::ioctl_with_val;
+/// # use vmm_sys_util::ioctl_io_nr;
 /// # const KVMIO: c_uint = 0xAE;
 /// # const KVM_CAP_USER_MEMORY: u32 = 3;
 /// # ioctl_io_nr!(KVM_CHECK_EXTENSION, KVMIO, 0x03);

--- a/src/linux/poll.rs
+++ b/src/linux/poll.rs
@@ -374,9 +374,8 @@ impl WatchingEvents {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
-/// use vmm_sys_util::eventfd::EventFd;
-/// use vmm_sys_util::poll::{EpollContext, EpollEvents};
+/// # use vmm_sys_util::eventfd::EventFd;
+/// # use vmm_sys_util::poll::{EpollContext, EpollEvents};
 ///
 /// let evt = EventFd::new(0).unwrap();
 /// let ctx: EpollContext<u32> = EpollContext::new().unwrap();
@@ -405,8 +404,7 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::poll::EpollContext;
+    /// # use vmm_sys_util::poll::EpollContext;
     ///
     /// let ctx: EpollContext<usize> = EpollContext::new().unwrap();
     /// ```
@@ -439,9 +437,8 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::eventfd::EventFd;
-    /// use vmm_sys_util::poll::EpollContext;
+    /// # use vmm_sys_util::eventfd::EventFd;
+    /// # use vmm_sys_util::poll::EpollContext;
     ///
     /// let evt = EventFd::new(0).unwrap();
     /// let ctx: EpollContext<u32> = EpollContext::new().unwrap();
@@ -468,9 +465,8 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::eventfd::EventFd;
-    /// use vmm_sys_util::poll::{EpollContext, WatchingEvents};
+    /// # use vmm_sys_util::eventfd::EventFd;
+    /// # use vmm_sys_util::poll::{EpollContext, WatchingEvents};
     ///
     /// let evt = EventFd::new(0).unwrap();
     /// let ctx: EpollContext<u32> = EpollContext::new().unwrap();
@@ -517,9 +513,8 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::eventfd::EventFd;
-    /// use vmm_sys_util::poll::{EpollContext, WatchingEvents};
+    /// # use vmm_sys_util::eventfd::EventFd;
+    /// # use vmm_sys_util::poll::{EpollContext, WatchingEvents};
     ///
     /// let evt = EventFd::new(0).unwrap();
     /// let ctx: EpollContext<u32> = EpollContext::new().unwrap();
@@ -563,9 +558,8 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::eventfd::EventFd;
-    /// use vmm_sys_util::poll::EpollContext;
+    /// # use vmm_sys_util::eventfd::EventFd;
+    /// # use vmm_sys_util::poll::EpollContext;
     ///
     /// let evt = EventFd::new(0).unwrap();
     /// let ctx: EpollContext<u32> = EpollContext::new().unwrap();
@@ -604,9 +598,8 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    /// use vmm_sys_util::eventfd::EventFd;
-    /// use vmm_sys_util::poll::{EpollContext, EpollEvents};
+    /// # use vmm_sys_util::eventfd::EventFd;
+    /// # use vmm_sys_util::poll::{EpollContext, EpollEvents};
     ///
     /// let evt = EventFd::new(0).unwrap();
     /// let ctx: EpollContext<u32> = EpollContext::new().unwrap();
@@ -637,10 +630,9 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// # use std::time::Duration;
-    /// use vmm_sys_util::eventfd::EventFd;
-    /// use vmm_sys_util::poll::{EpollContext, EpollEvents};
+    /// # use vmm_sys_util::eventfd::EventFd;
+    /// # use vmm_sys_util::poll::{EpollContext, EpollEvents};
     ///
     /// let evt = EventFd::new(0).unwrap();
     /// let ctx: EpollContext<u32> = EpollContext::new().unwrap();

--- a/src/linux/signal.rs
+++ b/src/linux/signal.rs
@@ -117,7 +117,6 @@ pub fn SIGRTMAX() -> c_int {
 /// # Examples
 ///
 /// ```
-/// # extern crate vmm_sys_util;
 /// # use vmm_sys_util::signal::validate_signal_num;
 /// let num = validate_signal_num(1).unwrap();
 /// ```
@@ -145,8 +144,6 @@ pub fn validate_signal_num(num: c_int) -> errno::Result<()> {
 /// # Examples
 ///
 /// ```
-/// # extern crate libc;
-/// # extern crate vmm_sys_util;
 /// # use libc::{c_int, c_void, siginfo_t, SA_SIGINFO};
 /// # use vmm_sys_util::signal::{register_signal_handler, SignalHandler};
 /// extern "C" fn handle_signal(_: c_int, _: *mut siginfo_t, _: *mut c_void) {}
@@ -195,8 +192,6 @@ pub fn register_signal_handler(num: c_int, handler: SignalHandler) -> errno::Res
 /// # Examples
 ///
 /// ```
-/// # extern crate libc;
-/// # extern crate vmm_sys_util;
 /// # use libc::sigismember;
 /// # use vmm_sys_util::signal::create_sigset;
 /// let sigset = create_sigset(&[1]).unwrap();
@@ -235,7 +230,6 @@ pub fn create_sigset(signals: &[c_int]) -> errno::Result<sigset_t> {
 /// # Examples
 ///
 /// ```
-/// # extern crate vmm_sys_util;
 /// # use vmm_sys_util::signal::{block_signal, get_blocked_signals};
 /// block_signal(1).unwrap();
 /// assert!(get_blocked_signals().unwrap().contains(&(1)));
@@ -274,7 +268,6 @@ pub fn get_blocked_signals() -> SignalResult<Vec<c_int>> {
 /// # Examples
 ///
 /// ```
-/// # extern crate vmm_sys_util;
 /// # use vmm_sys_util::signal::block_signal;
 /// block_signal(1).unwrap();
 /// ```
@@ -311,7 +304,6 @@ pub fn block_signal(num: c_int) -> SignalResult<()> {
 /// # Examples
 ///
 /// ```
-/// # extern crate vmm_sys_util;
 /// # use vmm_sys_util::signal::{block_signal, get_blocked_signals, unblock_signal};
 /// block_signal(1).unwrap();
 /// assert!(get_blocked_signals().unwrap().contains(&(1)));
@@ -337,8 +329,6 @@ pub fn unblock_signal(num: c_int) -> SignalResult<()> {
 /// # Examples
 ///
 /// ```
-/// # extern crate libc;
-/// # extern crate vmm_sys_util;
 /// # use libc::{pthread_kill, sigismember, sigpending, sigset_t};
 /// # use std::mem;
 /// # use std::thread;

--- a/src/linux/signal.rs
+++ b/src/linux/signal.rs
@@ -117,9 +117,8 @@ pub fn SIGRTMAX() -> c_int {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
-/// use vmm_sys_util::signal::validate_signal_num;
-///
+/// # extern crate vmm_sys_util;
+/// # use vmm_sys_util::signal::validate_signal_num;
 /// let num = validate_signal_num(1).unwrap();
 /// ```
 pub fn validate_signal_num(num: c_int) -> errno::Result<()> {
@@ -147,10 +146,9 @@ pub fn validate_signal_num(num: c_int) -> errno::Result<()> {
 ///
 /// ```
 /// # extern crate libc;
-/// extern crate vmm_sys_util;
+/// # extern crate vmm_sys_util;
 /// # use libc::{c_int, c_void, siginfo_t, SA_SIGINFO};
-/// use vmm_sys_util::signal::{register_signal_handler, SignalHandler};
-///
+/// # use vmm_sys_util::signal::{register_signal_handler, SignalHandler};
 /// extern "C" fn handle_signal(_: c_int, _: *mut siginfo_t, _: *mut c_void) {}
 /// register_signal_handler(0, handle_signal);
 /// ```
@@ -198,10 +196,9 @@ pub fn register_signal_handler(num: c_int, handler: SignalHandler) -> errno::Res
 ///
 /// ```
 /// # extern crate libc;
-/// extern crate vmm_sys_util;
+/// # extern crate vmm_sys_util;
 /// # use libc::sigismember;
-/// use vmm_sys_util::signal::create_sigset;
-///
+/// # use vmm_sys_util::signal::create_sigset;
 /// let sigset = create_sigset(&[1]).unwrap();
 ///
 /// unsafe {
@@ -238,9 +235,8 @@ pub fn create_sigset(signals: &[c_int]) -> errno::Result<sigset_t> {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
-/// use vmm_sys_util::signal::{block_signal, get_blocked_signals};
-///
+/// # extern crate vmm_sys_util;
+/// # use vmm_sys_util::signal::{block_signal, get_blocked_signals};
 /// block_signal(1).unwrap();
 /// assert!(get_blocked_signals().unwrap().contains(&(1)));
 /// ```
@@ -278,9 +274,8 @@ pub fn get_blocked_signals() -> SignalResult<Vec<c_int>> {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
-/// use vmm_sys_util::signal::block_signal;
-///
+/// # extern crate vmm_sys_util;
+/// # use vmm_sys_util::signal::block_signal;
 /// block_signal(1).unwrap();
 /// ```
 // Allowing comparison chain because rewriting it with match makes the code less readable.
@@ -316,9 +311,8 @@ pub fn block_signal(num: c_int) -> SignalResult<()> {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
-/// use vmm_sys_util::signal::{block_signal, get_blocked_signals, unblock_signal};
-///
+/// # extern crate vmm_sys_util;
+/// # use vmm_sys_util::signal::{block_signal, get_blocked_signals, unblock_signal};
 /// block_signal(1).unwrap();
 /// assert!(get_blocked_signals().unwrap().contains(&(1)));
 /// unblock_signal(1).unwrap();
@@ -344,13 +338,12 @@ pub fn unblock_signal(num: c_int) -> SignalResult<()> {
 ///
 /// ```
 /// # extern crate libc;
-/// extern crate vmm_sys_util;
+/// # extern crate vmm_sys_util;
 /// # use libc::{pthread_kill, sigismember, sigpending, sigset_t};
 /// # use std::mem;
 /// # use std::thread;
 /// # use std::time::Duration;
-/// use vmm_sys_util::signal::{block_signal, clear_signal, Killable};
-///
+/// # use vmm_sys_util::signal::{block_signal, clear_signal, Killable};
 /// block_signal(1).unwrap();
 /// let killable = thread::spawn(move || {
 ///     thread::sleep(Duration::from_millis(100));

--- a/src/linux/timerfd.rs
+++ b/src/linux/timerfd.rs
@@ -73,7 +73,6 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use std::time::Duration;
     /// # use vmm_sys_util::timerfd::TimerFd;
     /// let mut timer = TimerFd::new().unwrap();
@@ -124,7 +123,6 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use std::time::Duration;
     /// # use std::thread::sleep;
     /// # use vmm_sys_util::timerfd::TimerFd;
@@ -154,7 +152,6 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use std::time::Duration;
     /// # use vmm_sys_util::timerfd::TimerFd;
     /// let mut timer = TimerFd::new().unwrap();
@@ -184,7 +181,6 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use std::time::Duration;
     /// # use vmm_sys_util::timerfd::TimerFd;
     /// let mut timer = TimerFd::new().unwrap();

--- a/src/linux/timerfd.rs
+++ b/src/linux/timerfd.rs
@@ -73,10 +73,9 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
+    /// # extern crate vmm_sys_util;
     /// # use std::time::Duration;
-    /// use vmm_sys_util::timerfd::TimerFd;
-    ///
+    /// # use vmm_sys_util::timerfd::TimerFd;
     /// let mut timer = TimerFd::new().unwrap();
     /// let dur = Duration::from_millis(100);
     /// let interval = Duration::from_millis(100);
@@ -125,11 +124,10 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
+    /// # extern crate vmm_sys_util;
     /// # use std::time::Duration;
     /// # use std::thread::sleep;
-    /// use vmm_sys_util::timerfd::TimerFd;
-    ///
+    /// # use vmm_sys_util::timerfd::TimerFd;
     /// let mut timer = TimerFd::new().unwrap();
     /// let dur = Duration::from_millis(100);
     /// let interval = Duration::from_millis(100);
@@ -156,10 +154,9 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
+    /// # extern crate vmm_sys_util;
     /// # use std::time::Duration;
-    /// use vmm_sys_util::timerfd::TimerFd;
-    ///
+    /// # use vmm_sys_util::timerfd::TimerFd;
     /// let mut timer = TimerFd::new().unwrap();
     /// let dur = Duration::from_millis(100);
     ///
@@ -187,10 +184,9 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
+    /// # extern crate vmm_sys_util;
     /// # use std::time::Duration;
-    /// use vmm_sys_util::timerfd::TimerFd;
-    ///
+    /// # use vmm_sys_util::timerfd::TimerFd;
     /// let mut timer = TimerFd::new().unwrap();
     /// let dur = Duration::from_millis(100);
     ///

--- a/src/tempfile.rs
+++ b/src/tempfile.rs
@@ -14,11 +14,10 @@
 //! # Examples
 //!
 //! ```
-//! use std::env::temp_dir;
-//! use std::io::Write;
-//! use std::path::{Path, PathBuf};
-//! use vmm_sys_util::tempfile::TempFile;
-//!
+//! # use std::env::temp_dir;
+//! # use std::io::Write;
+//! # use std::path::{Path, PathBuf};
+//! # use vmm_sys_util::tempfile::TempFile;
 //! let mut prefix = temp_dir();
 //! prefix.push("tempfile");
 //! let t = TempFile::new_with_prefix(prefix).unwrap();

--- a/src/unix/event.rs
+++ b/src/unix/event.rs
@@ -32,9 +32,9 @@ bitflags::bitflags! {
 /// # Examples
 ///
 /// ```
-/// use std::os::fd::FromRawFd;
-/// use std::os::unix::io::IntoRawFd;
-/// use vmm_sys_util::event::EventNotifier;
+/// # use std::os::fd::FromRawFd;
+/// # use std::os::unix::io::IntoRawFd;
+/// # use vmm_sys_util::event::EventNotifier;
 /// let (_, writer) = std::io::pipe().expect("Failed to create pipe");
 /// let notifier = unsafe { EventNotifier::from_raw_fd(writer.into_raw_fd()) };
 /// ```
@@ -86,9 +86,9 @@ impl IntoRawFd for EventNotifier {
 /// # Examples
 ///
 /// ```
-/// use std::os::fd::FromRawFd;
-/// use std::os::unix::io::IntoRawFd;
-/// use vmm_sys_util::event::EventConsumer;
+/// # use std::os::fd::FromRawFd;
+/// # use std::os::unix::io::IntoRawFd;
+/// # use vmm_sys_util::event::EventConsumer;
 /// let (reader, _) = std::io::pipe().expect("Failed to create pipe");
 /// let consumer = unsafe { EventConsumer::from_raw_fd(reader.into_raw_fd()) };
 /// ```
@@ -171,7 +171,7 @@ fn fcntl_setfd(file: &File, flag: i32) -> Result<(), io::Error> {
 /// # Examples
 ///
 /// ```
-/// use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
+/// # use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
 /// let (consumer, notifier) = new_event_consumer_and_notifier(EventFlag::NONBLOCK)
 ///     .expect("Failed to create notifier and consumer");
 /// notifier.notify().unwrap();
@@ -213,7 +213,7 @@ pub fn new_event_consumer_and_notifier(
 /// # Examples
 ///
 /// ```
-/// use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
+/// # use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
 /// let (consumer, notifier) = new_event_consumer_and_notifier(EventFlag::NONBLOCK)
 ///     .expect("Failed to create consumer and notifier");
 /// notifier.notify().unwrap();

--- a/src/unix/sock_ctrl_msg.rs
+++ b/src/unix/sock_ctrl_msg.rs
@@ -234,12 +234,12 @@ unsafe fn raw_recvmsg(
 /// # Examples
 ///
 /// ```
-/// use std::os::fd::{AsRawFd, FromRawFd};
-/// use std::os::unix::net::UnixDatagram;
+/// # use std::os::fd::{AsRawFd, FromRawFd};
+/// # use std::os::unix::net::UnixDatagram;
 ///
-/// use libc::{c_void, iovec};
-/// use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag, EventNotifier};
-/// use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+/// # use libc::{c_void, iovec};
+/// # use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag, EventNotifier};
+/// # use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 ///
 /// let (s1, s2) = UnixDatagram::pair().expect("failed to create socket pair");
 /// let (consumer, fd_to_send) = new_event_consumer_and_notifier(EventFlag::empty())

--- a/src/unix/terminal.rs
+++ b/src/unix/terminal.rs
@@ -122,11 +122,10 @@ pub unsafe trait Terminal {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
+    /// # extern crate vmm_sys_util;
     /// # use std::io;
     /// # use std::os::unix::io::RawFd;
-    /// use vmm_sys_util::terminal::Terminal;
-    ///
+    /// # use vmm_sys_util::terminal::Terminal;
     /// let stdin_handle = io::stdin();
     /// let stdin = stdin_handle.lock();
     /// assert!(stdin.set_non_block(true).is_ok());

--- a/src/unix/terminal.rs
+++ b/src/unix/terminal.rs
@@ -122,7 +122,6 @@ pub unsafe trait Terminal {
     /// # Examples
     ///
     /// ```
-    /// # extern crate vmm_sys_util;
     /// # use std::io;
     /// # use std::os::unix::io::RawFd;
     /// # use vmm_sys_util::terminal::Terminal;


### PR DESCRIPTION
Use Rust's doc-test hiding feature (# prefix) to hide extern crate and use statements from rendered documentation while keeping them for compilation. This reduces visual clutter in the docs and lets users focus on the actual usage code.

Files updated:
- src/errno.rs
- src/tempfile.rs
- src/align.rs
- src/unix/event.rs
- src/linux/epoll.rs
- src/linux/eventfd.rs
- src/linux/timerfd.rs
- src/linux/signal.rs
- src/linux/ioctl.rs
- src/unix/terminal.rs
- src/fam.rs

Fixes: rust-vmm/rust-vmm#5

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
