### PR TITLE
macos: add epoll and eventfd compatibility shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@
 ### Added
 
 - [[#254](https://github.com/rust-vmm/vmm-sys-util/pull/254)]: Support `TFD_NONBLOCK` for `timerfd::TimerFd`.
+- Add macOS compatibility shims for the Linux `epoll` and `eventfd`
+  APIs (`macos::epoll` backed by `kqueue`, `macos::eventfd` backed by
+  a pipe pair), adapted from the libkrun project. Re-exported at the
+  crate root on `target_os = "macos"` so that `vmm_sys_util::epoll`
+  and `vmm_sys_util::eventfd` are available there.
+
+  This is a prerequisite for building the rust-vmm `vhost` and
+  `vhost-user-backend` crates on macOS: both expose `vmm_sys_util`
+  types in their public API (e.g. `VhostBackend::set_vring_call`,
+  `set_vring_kick`, `set_vring_err` each take `&EventFd`;
+  `VhostUserBackend::handle_event` receives an `EventSet`; the
+  internal vring event loop in `vhost-user-backend` is driven by
+  `Epoll` / `EpollEvent` / `ControlOperation`). Without a macOS
+  implementation in `vmm-sys-util`, those crates do not compile on
+  macOS, which in turn blocks downstream vhost-user daemons such as
+  virtiofsd from running there.
 
 ## v0.15.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/rust-vmm/vmm-sys-util"
 readme = "README.md"
 keywords = ["utils"]
 edition = "2021"
-license = "BSD-3-Clause"
+license = "BSD-3-Clause AND Apache-2.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/LICENSE-Apache-2.0
+++ b/LICENSE-Apache-2.0
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,11 @@ mod linux;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub use crate::linux::*;
 
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub use crate::macos::*;
+
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]

--- a/src/macos/epoll.rs
+++ b/src/macos/epoll.rs
@@ -1,0 +1,612 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2021 Sergio Lopez. All rights reserved.
+// Copyright 2026 Proofpoint, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from the libkrun project, preserving its original Apache-2.0
+// license. Upstream source:
+//   https://github.com/containers/libkrun/blob/a3b7ae213195c9f871a17c72f0d020e46ed90584/src/utils/src/macos/epoll.rs
+
+//! Safe wrappers emulating the Linux
+//! [`epoll`](http://man7.org/linux/man-pages/man7/epoll.7.html) API using macOS kqueue.
+
+use std::io;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::ptr;
+
+use bitflags::bitflags;
+
+/// Wrapper over `EPOLL_CTL_*` operations that can be performed on a file descriptor.
+#[derive(Debug)]
+#[repr(i32)]
+pub enum ControlOperation {
+    /// Add a file descriptor to the interest list.
+    Add = 1,
+    /// Change the settings associated with a file descriptor that is
+    /// already in the interest list.
+    Modify = 3,
+    /// Remove a file descriptor from the interest list.
+    Delete = 2,
+}
+
+bitflags! {
+    /// The type of events we can monitor a file descriptor for.
+    ///
+    /// Provides the same flags as the Linux epoll API, mapped to kqueue equivalents.
+    pub struct EventSet: u32 {
+        /// The associated file descriptor is available for read operations.
+        const IN = 0x001;
+        /// The associated file descriptor is available for write operations.
+        const OUT = 0x004;
+        /// Error condition happened on the associated file descriptor.
+        const ERROR = 0x008;
+        /// This can be used to detect peer shutdown when using Edge Triggered monitoring.
+        /// Note: kqueue always reports EV_EOF; this is mapped from that.
+        const READ_HANG_UP = 0x2000;
+        /// Sets the Edge Triggered behavior for the associated file descriptor.
+        const EDGE_TRIGGERED = (1 << 31);
+        /// Hang up happened on the associated file descriptor.
+        const HANG_UP = 0x010;
+        /// There is an exceptional condition on that file descriptor.
+        const PRIORITY = 0x002;
+        /// The event is considered as being "processed".
+        const WAKE_UP = (1 << 29);
+        /// Sets the one-shot behavior for the associated file descriptor.
+        const ONE_SHOT = (1 << 30);
+        /// Sets an exclusive wake up mode.
+        const EXCLUSIVE = (1 << 28);
+    }
+}
+
+/// Wrapper over an epoll event, backed by kqueue on macOS.
+///
+/// Fields are public to match the Linux `epoll_event` struct layout,
+/// which is accessed directly by consumers via `Deref`.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct EpollEvent {
+    /// Event mask (combination of `EventSet` bits).
+    pub events: u32,
+    /// User data associated with this event.
+    pub u64: u64,
+}
+
+impl std::fmt::Debug for EpollEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{ events: {}, data: {} }}", self.events(), self.data())
+    }
+}
+
+impl EpollEvent {
+    /// Create a new EpollEvent instance.
+    ///
+    /// # Arguments
+    ///
+    /// `events` - contains an event mask.
+    /// `data` - a user data variable.
+    pub fn new(events: EventSet, data: u64) -> Self {
+        EpollEvent {
+            events: events.bits(),
+            u64: data,
+        }
+    }
+
+    /// Returns the raw events bitmask.
+    pub fn events(&self) -> u32 {
+        self.events
+    }
+
+    /// Returns the `EventSet` corresponding to the events.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the events contain invalid bits.
+    pub fn event_set(&self) -> EventSet {
+        EventSet::from_bits(self.events()).unwrap()
+    }
+
+    /// Returns the user data value.
+    pub fn data(&self) -> u64 {
+        self.u64
+    }
+
+    /// Converts the data to a RawFd.
+    ///
+    /// This conversion is lossy when the data does not correspond to a RawFd.
+    pub fn fd(&self) -> RawFd {
+        self.u64 as i32
+    }
+}
+
+/// Wrapper over epoll functionality, backed by kqueue on macOS.
+#[derive(Debug)]
+pub struct Epoll {
+    kqueue_fd: RawFd,
+}
+
+impl Epoll {
+    /// Create a new epoll-like instance backed by kqueue.
+    pub fn new() -> io::Result<Self> {
+        // SAFETY: kqueue() is safe and we check the return value.
+        let kqueue_fd = unsafe { libc::kqueue() };
+        if kqueue_fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Epoll { kqueue_fd })
+    }
+
+    /// Register, modify, or remove interest in events for a file descriptor.
+    ///
+    /// Maps epoll_ctl semantics to kqueue kevent operations.
+    ///
+    /// Note: `READ_HANG_UP` (`EPOLLRDHUP`) registration is ignored since kqueue
+    /// always reports `EV_EOF` on read hang-up. `wait()` will include
+    /// `READ_HANG_UP` in returned events when EOF is detected on a read filter.
+    pub fn ctl(&self, operation: ControlOperation, fd: RawFd, event: EpollEvent) -> io::Result<()> {
+        let eset = EventSet::from_bits(event.events).unwrap_or(EventSet::empty());
+
+        match operation {
+            ControlOperation::Add | ControlOperation::Modify => {
+                if matches!(operation, ControlOperation::Modify) {
+                    // Linux `epoll_ctl(EPOLL_CTL_MOD)` replaces the event mask
+                    // and user data for `fd`. kqueue has no equivalent single
+                    // operation: `EV_ADD` on an existing filter updates its
+                    // flags and udata, but leaves the unrelated filter
+                    // (`EVFILT_READ` vs `EVFILT_WRITE`) registered from a
+                    // prior `Add`. Clear both filters first so the subsequent
+                    // `EV_ADD` calls below are the only registrations that
+                    // remain for this fd.
+                    let del_kevs = [
+                        libc::kevent {
+                            ident: fd as usize,
+                            filter: libc::EVFILT_READ,
+                            flags: libc::EV_DELETE,
+                            fflags: 0,
+                            data: 0,
+                            udata: ptr::null_mut(),
+                        },
+                        libc::kevent {
+                            ident: fd as usize,
+                            filter: libc::EVFILT_WRITE,
+                            flags: libc::EV_DELETE,
+                            fflags: 0,
+                            data: 0,
+                            udata: ptr::null_mut(),
+                        },
+                    ];
+                    // SAFETY: We provide a valid kqueue fd and a valid kevent
+                    // array; errors are ignored because a filter that was
+                    // never registered returns `ENOENT`, which is expected.
+                    let _ = unsafe {
+                        libc::kevent(
+                            self.kqueue_fd,
+                            del_kevs.as_ptr(),
+                            del_kevs.len() as i32,
+                            ptr::null_mut(),
+                            0,
+                            ptr::null(),
+                        )
+                    };
+                }
+
+                let mut kevs: Vec<libc::kevent> = Vec::new();
+                let mut flags: u16 = libc::EV_ADD;
+                if eset.contains(EventSet::EDGE_TRIGGERED) {
+                    flags |= libc::EV_CLEAR;
+                }
+                if eset.contains(EventSet::ONE_SHOT) {
+                    flags |= libc::EV_ONESHOT;
+                }
+
+                if eset.contains(EventSet::IN) || eset.contains(EventSet::READ_HANG_UP) {
+                    kevs.push(libc::kevent {
+                        ident: fd as usize,
+                        filter: libc::EVFILT_READ,
+                        flags,
+                        fflags: 0,
+                        data: 0,
+                        udata: event.u64 as *mut libc::c_void,
+                    });
+                }
+                if eset.contains(EventSet::OUT) {
+                    kevs.push(libc::kevent {
+                        ident: fd as usize,
+                        filter: libc::EVFILT_WRITE,
+                        flags,
+                        fflags: 0,
+                        data: 0,
+                        udata: event.u64 as *mut libc::c_void,
+                    });
+                }
+
+                if kevs.is_empty() {
+                    return Ok(());
+                }
+
+                // SAFETY: We provide valid kqueue fd, valid kevent array, and check return.
+                let ret = unsafe {
+                    libc::kevent(
+                        self.kqueue_fd,
+                        kevs.as_ptr(),
+                        kevs.len() as i32,
+                        ptr::null_mut(),
+                        0,
+                        ptr::null(),
+                    )
+                };
+                if ret < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+            }
+            ControlOperation::Delete => {
+                let eset = EventSet::from_bits(event.events).unwrap_or(EventSet::empty());
+                let mut kevs: Vec<libc::kevent> = Vec::new();
+
+                // If no specific events, remove both read and write filters.
+                if eset.is_empty() {
+                    kevs.push(libc::kevent {
+                        ident: fd as usize,
+                        filter: libc::EVFILT_READ,
+                        flags: libc::EV_DELETE,
+                        fflags: 0,
+                        data: 0,
+                        udata: ptr::null_mut(),
+                    });
+                    kevs.push(libc::kevent {
+                        ident: fd as usize,
+                        filter: libc::EVFILT_WRITE,
+                        flags: libc::EV_DELETE,
+                        fflags: 0,
+                        data: 0,
+                        udata: ptr::null_mut(),
+                    });
+                } else {
+                    if eset.contains(EventSet::IN) {
+                        kevs.push(libc::kevent {
+                            ident: fd as usize,
+                            filter: libc::EVFILT_READ,
+                            flags: libc::EV_DELETE,
+                            fflags: 0,
+                            data: 0,
+                            udata: ptr::null_mut(),
+                        });
+                    }
+                    if eset.contains(EventSet::OUT) {
+                        kevs.push(libc::kevent {
+                            ident: fd as usize,
+                            filter: libc::EVFILT_WRITE,
+                            flags: libc::EV_DELETE,
+                            fflags: 0,
+                            data: 0,
+                            udata: ptr::null_mut(),
+                        });
+                    }
+                }
+
+                // Ignore errors on delete - the fd may not be registered for all filters.
+                // SAFETY: We provide a valid kqueue fd and a valid kevent array; the
+                // return value is intentionally discarded because an `EV_DELETE` on a
+                // filter that was never registered returns `ENOENT`, which is not an
+                // error for our purposes.
+                let _ = unsafe {
+                    libc::kevent(
+                        self.kqueue_fd,
+                        kevs.as_ptr(),
+                        kevs.len() as i32,
+                        ptr::null_mut(),
+                        0,
+                        ptr::null(),
+                    )
+                };
+            }
+        }
+        Ok(())
+    }
+
+    /// Wait for events, similar to `epoll_wait`.
+    ///
+    /// Returns the number of ready file descriptors.
+    ///
+    /// # Arguments
+    ///
+    /// * `timeout` - timeout in milliseconds. -1 for infinite wait.
+    /// * `events` - buffer to store ready events.
+    pub fn wait(&self, timeout: i32, events: &mut [EpollEvent]) -> io::Result<usize> {
+        let ts = if timeout >= 0 {
+            libc::timespec {
+                tv_sec: (timeout / 1000) as libc::time_t,
+                tv_nsec: ((timeout % 1000) as libc::c_long) * 1_000_000,
+            }
+        } else {
+            // For infinite wait, we still need a timespec pointer.
+            // Pass null below for infinite wait.
+            libc::timespec {
+                tv_sec: 0,
+                tv_nsec: 0,
+            }
+        };
+
+        let ts_ptr = if timeout >= 0 {
+            &ts as *const libc::timespec
+        } else {
+            ptr::null()
+        };
+
+        let max_events = events.len();
+        let mut kevs = vec![
+            libc::kevent {
+                ident: 0,
+                filter: 0,
+                flags: 0,
+                fflags: 0,
+                data: 0,
+                udata: ptr::null_mut(),
+            };
+            max_events
+        ];
+
+        // SAFETY: We provide a valid kqueue fd, a valid kevent array, and check return.
+        let ret = unsafe {
+            libc::kevent(
+                self.kqueue_fd,
+                ptr::null(),
+                0,
+                kevs.as_mut_ptr(),
+                max_events as i32,
+                ts_ptr,
+            )
+        };
+
+        if ret < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let nevents = ret as usize;
+
+        for i in 0..nevents {
+            let kev = &kevs[i];
+            let mut event_bits = EventSet::empty();
+
+            match kev.filter {
+                libc::EVFILT_READ => {
+                    event_bits |= EventSet::IN;
+                    if kev.flags & libc::EV_EOF != 0 {
+                        event_bits |= EventSet::READ_HANG_UP;
+                    }
+                }
+                libc::EVFILT_WRITE => {
+                    event_bits |= EventSet::OUT;
+                    if kev.flags & libc::EV_EOF != 0 {
+                        event_bits |= EventSet::HANG_UP;
+                    }
+                }
+                _ => {}
+            }
+
+            if kev.flags & libc::EV_ERROR != 0 {
+                event_bits |= EventSet::ERROR;
+            }
+
+            events[i] = EpollEvent {
+                events: event_bits.bits(),
+                u64: kev.udata as u64,
+            };
+        }
+
+        Ok(nevents)
+    }
+}
+
+impl AsRawFd for Epoll {
+    fn as_raw_fd(&self) -> RawFd {
+        self.kqueue_fd
+    }
+}
+
+impl Drop for Epoll {
+    fn drop(&mut self) {
+        // SAFETY: fd was opened with kqueue() and is valid.
+        unsafe {
+            libc::close(self.kqueue_fd);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::eventfd::{EventFd, EFD_NONBLOCK};
+
+    #[test]
+    fn test_event_ops() {
+        let mut event = EpollEvent::default();
+        assert_eq!(event.events(), 0);
+        assert_eq!(event.data(), 0);
+
+        event = EpollEvent::new(EventSet::IN, 2);
+        assert_eq!(event.events(), EventSet::IN.bits());
+        assert_eq!(event.event_set(), EventSet::IN);
+
+        assert_eq!(event.data(), 2);
+        assert_eq!(event.fd(), 2);
+    }
+
+    #[test]
+    fn test_events_debug() {
+        let events = EpollEvent::new(EventSet::IN, 42);
+        assert_eq!(format!("{:?}", events), "{ events: 1, data: 42 }")
+    }
+
+    #[test]
+    fn test_epoll() {
+        const DEFAULT_TIMEOUT: i32 = 250;
+        const EVENT_BUFFER_SIZE: usize = 128;
+
+        let epoll = Epoll::new().unwrap();
+
+        let event_fd_1 = EventFd::new(EFD_NONBLOCK).unwrap();
+        event_fd_1.write(1).unwrap();
+
+        let event_1 = EpollEvent::new(EventSet::IN, event_fd_1.as_raw_fd() as u64);
+
+        assert!(epoll
+            .ctl(ControlOperation::Add, event_fd_1.as_raw_fd(), event_1)
+            .is_ok());
+
+        let event_fd_2 = EventFd::new(EFD_NONBLOCK).unwrap();
+        event_fd_2.write(1).unwrap();
+        assert!(epoll
+            .ctl(
+                ControlOperation::Add,
+                event_fd_2.as_raw_fd(),
+                EpollEvent::new(EventSet::IN, 10)
+            )
+            .is_ok());
+
+        let mut ready_events = vec![EpollEvent::default(); EVENT_BUFFER_SIZE];
+        let ev_count = epoll.wait(DEFAULT_TIMEOUT, &mut ready_events[..]).unwrap();
+
+        assert_eq!(ev_count, 2);
+        assert_eq!(ready_events[0].data(), event_fd_1.as_raw_fd() as u64);
+        assert_eq!(ready_events[1].data(), 10);
+
+        assert_eq!(ready_events[0].events(), EventSet::IN.bits());
+        assert_eq!(ready_events[1].events(), EventSet::IN.bits());
+
+        // Delete a fd from the interest list.
+        assert!(epoll
+            .ctl(
+                ControlOperation::Delete,
+                event_fd_2.as_raw_fd(),
+                EpollEvent::default()
+            )
+            .is_ok());
+
+        let ev_count = epoll.wait(DEFAULT_TIMEOUT, &mut ready_events[..]).unwrap();
+        assert_eq!(ev_count, 1);
+        assert_eq!(ready_events[0].data(), event_fd_1.as_raw_fd() as u64);
+        assert_eq!(ready_events[0].events(), EventSet::IN.bits());
+    }
+
+    #[test]
+    fn test_epoll_modify() {
+        const DEFAULT_TIMEOUT: i32 = 250;
+        const EVENT_BUFFER_SIZE: usize = 8;
+
+        let epoll = Epoll::new().unwrap();
+        let event_fd = EventFd::new(EFD_NONBLOCK).unwrap();
+        event_fd.write(1).unwrap();
+
+        epoll
+            .ctl(
+                ControlOperation::Add,
+                event_fd.as_raw_fd(),
+                EpollEvent::new(EventSet::IN, 11),
+            )
+            .unwrap();
+
+        let mut ready_events = vec![EpollEvent::default(); EVENT_BUFFER_SIZE];
+        let ev_count = epoll.wait(DEFAULT_TIMEOUT, &mut ready_events[..]).unwrap();
+        assert_eq!(ev_count, 1);
+        assert_eq!(ready_events[0].data(), 11);
+        assert_eq!(ready_events[0].events(), EventSet::IN.bits());
+
+        // Modify the registration to carry a new user data value.
+        epoll
+            .ctl(
+                ControlOperation::Modify,
+                event_fd.as_raw_fd(),
+                EpollEvent::new(EventSet::IN, 42),
+            )
+            .unwrap();
+
+        let ev_count = epoll.wait(DEFAULT_TIMEOUT, &mut ready_events[..]).unwrap();
+        assert_eq!(ev_count, 1);
+        assert_eq!(ready_events[0].data(), 42);
+        assert_eq!(ready_events[0].events(), EventSet::IN.bits());
+
+        // Modify again to remove all interest; the next wait must not
+        // return the previously registered read event.
+        epoll
+            .ctl(
+                ControlOperation::Modify,
+                event_fd.as_raw_fd(),
+                EpollEvent::default(),
+            )
+            .unwrap();
+
+        let ev_count = epoll.wait(DEFAULT_TIMEOUT, &mut ready_events[..]).unwrap();
+        assert_eq!(ev_count, 0);
+    }
+
+    #[test]
+    fn test_epoll_timeout() {
+        const TIMEOUT_MS: i32 = 100;
+        let epoll = Epoll::new().unwrap();
+        let mut ready_events = vec![EpollEvent::default(); 4];
+        let ev_count = epoll.wait(TIMEOUT_MS, &mut ready_events[..]).unwrap();
+        assert_eq!(ev_count, 0);
+    }
+
+    // The following tests pin macOS-specific semantics that deliberately
+    // diverge from the Linux `epoll_ctl` contract. The kqueue-backed
+    // implementation does not track registration state itself; it relies
+    // on the kernel's kqueue behavior, which is more permissive than
+    // Linux's epoll. These tests exist to:
+    //   1. make the divergence visible to reviewers, and
+    //   2. catch any future change that silently starts rejecting these
+    //      operations (which would break downstream callers that rely on
+    //      the current permissive behavior).
+
+    #[test]
+    fn test_add_is_idempotent() {
+        // Linux `epoll_ctl(EPOLL_CTL_ADD)` returns EEXIST when the fd is
+        // already in the interest list. kqueue's `EV_ADD` is idempotent
+        // and updates `udata`/flags on an existing filter, so the second
+        // `Add` below succeeds and effectively re-registers the filter.
+        let epoll = Epoll::new().unwrap();
+        let event_fd = EventFd::new(EFD_NONBLOCK).unwrap();
+        let ev = EpollEvent::new(EventSet::IN, event_fd.as_raw_fd() as u64);
+        epoll
+            .ctl(ControlOperation::Add, event_fd.as_raw_fd(), ev)
+            .unwrap();
+        epoll
+            .ctl(ControlOperation::Add, event_fd.as_raw_fd(), ev)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_modify_unregistered_succeeds() {
+        // Linux `epoll_ctl(EPOLL_CTL_MOD)` returns ENOENT when the fd is
+        // not in the interest list. Our `Modify` always issues a delete
+        // pass (whose errors are ignored) followed by `EV_ADD`, so it
+        // behaves like `Add` when the fd was never registered.
+        let epoll = Epoll::new().unwrap();
+        let event_fd = EventFd::new(EFD_NONBLOCK).unwrap();
+        epoll
+            .ctl(
+                ControlOperation::Modify,
+                event_fd.as_raw_fd(),
+                EpollEvent::new(EventSet::IN, event_fd.as_raw_fd() as u64),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_delete_unregistered_succeeds() {
+        // Linux `epoll_ctl(EPOLL_CTL_DEL)` returns ENOENT when the fd is
+        // not in the interest list. Our `Delete` intentionally swallows
+        // kevent errors: with two filters (`EVFILT_READ` + `EVFILT_WRITE`)
+        // per fd, a partial registration would otherwise always error.
+        let epoll = Epoll::new().unwrap();
+        let event_fd = EventFd::new(EFD_NONBLOCK).unwrap();
+        epoll
+            .ctl(
+                ControlOperation::Delete,
+                event_fd.as_raw_fd(),
+                EpollEvent::default(),
+            )
+            .unwrap();
+    }
+}

--- a/src/macos/eventfd.rs
+++ b/src/macos/eventfd.rs
@@ -1,0 +1,216 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2021 Sergio Lopez. All rights reserved.
+// Copyright 2026 Proofpoint, Inc. All rights reserved.
+// SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+//
+// Adapted from the libkrun project, preserving its original dual
+// Apache-2.0 / BSD-3-Clause license. Upstream source:
+//   https://github.com/containers/libkrun/blob/a3b7ae213195c9f871a17c72f0d020e46ed90584/src/utils/src/macos/eventfd.rs
+
+//! Structure and wrapper functions emulating
+//! [`eventfd`](http://man7.org/linux/man-pages/man2/eventfd.2.html) using a pipe pair.
+//!
+//! macOS does not have the `eventfd` syscall, so we emulate it with `pipe()`.
+
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+
+/// Equivalent to `libc::EFD_NONBLOCK` for pipe-based emulation.
+pub const EFD_NONBLOCK: i32 = 1;
+
+/// Equivalent to `libc::EFD_CLOEXEC` for pipe-based emulation.
+pub const EFD_CLOEXEC: i32 = 2;
+
+/// Equivalent to `libc::EFD_SEMAPHORE` for pipe-based emulation.
+/// Note: semaphore semantics are not fully implemented; reads do not return 1.
+pub const EFD_SEMAPHORE: i32 = 4;
+
+fn set_flags(fd: RawFd, flags: i32) -> io::Result<()> {
+    if flags & EFD_NONBLOCK != 0 {
+        // SAFETY: fd is a valid file descriptor.
+        let fl = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if fl < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: fd is a valid file descriptor.
+        let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, fl | libc::O_NONBLOCK) };
+        if ret < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    if flags & EFD_CLOEXEC != 0 {
+        // SAFETY: fd is a valid file descriptor.
+        let fl = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        if fl < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: fd is a valid file descriptor.
+        let ret = unsafe { libc::fcntl(fd, libc::F_SETFD, fl | libc::FD_CLOEXEC) };
+        if ret < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+/// A pipe-backed emulation of Linux
+/// [`eventfd`](http://man7.org/linux/man-pages/man2/eventfd.2.html).
+#[derive(Debug)]
+pub struct EventFd {
+    read_fd: File,
+    write_fd: File,
+}
+
+impl EventFd {
+    /// Create a new EventFd with an initial value.
+    ///
+    /// # Arguments
+    ///
+    /// * `flag`: Flags for the EventFd. Supports `EFD_NONBLOCK` and `EFD_CLOEXEC`.
+    pub fn new(flag: i32) -> io::Result<EventFd> {
+        let mut fds: [RawFd; 2] = [-1, -1];
+        // SAFETY: pipe() is safe and we check the return value.
+        let ret = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        if ret < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        set_flags(fds[0], flag)?;
+        set_flags(fds[1], flag)?;
+
+        Ok(EventFd {
+            // SAFETY: fds are valid file descriptors from pipe().
+            read_fd: unsafe { File::from_raw_fd(fds[0]) },
+            write_fd: unsafe { File::from_raw_fd(fds[1]) },
+        })
+    }
+
+    /// Add a value to the eventfd's counter.
+    ///
+    /// On pipe-based emulation, this writes the 8-byte value to the pipe.
+    /// If the pipe buffer is full, this returns EAGAIN (if nonblocking) or blocks.
+    pub fn write(&self, v: u64) -> io::Result<()> {
+        // We silently ignore EAGAIN on writes - if the pipe is full, the reader
+        // will still be notified (matching eventfd overflow behavior).
+        match (&self.write_fd).write_all(&v.to_ne_bytes()) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Read a value from the eventfd.
+    ///
+    /// If nothing has been written, this returns EAGAIN (if nonblocking) or blocks.
+    pub fn read(&self) -> io::Result<u64> {
+        let mut buf = [0u8; std::mem::size_of::<u64>()];
+        (&self.read_fd).read_exact(&mut buf)?;
+        Ok(u64::from_ne_bytes(buf))
+    }
+
+    /// Clone this EventFd, duplicating both the read and write file descriptors.
+    pub fn try_clone(&self) -> io::Result<EventFd> {
+        Ok(EventFd {
+            read_fd: self.read_fd.try_clone()?,
+            write_fd: self.write_fd.try_clone()?,
+        })
+    }
+}
+
+impl AsRawFd for EventFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.read_fd.as_raw_fd()
+    }
+}
+
+impl FromRawFd for EventFd {
+    /// Create an EventFd from a raw file descriptor.
+    ///
+    /// # Safety
+    ///
+    /// The fd must be the read end of a pipe pair. The write end will be duplicated
+    /// from the same fd, which means write operations will not work correctly unless
+    /// this fd is actually an eventfd-like descriptor (e.g., a pipe read end that has
+    /// a corresponding write end managed elsewhere).
+    ///
+    /// This is primarily provided for API compatibility. When receiving an fd from
+    /// QEMU's vhost-user protocol (which sends pipe fds on macOS), the fd is the
+    /// read end for kick events or the write end for call events.
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        EventFd {
+            read_fd: File::from_raw_fd(fd),
+            // We dup the fd for the write side. This is not ideal but maintains
+            // API compatibility. In practice, vhost-user backends receive separate
+            // fds for reading (kick) and writing (call).
+            write_fd: File::from_raw_fd(libc::dup(fd)),
+        }
+    }
+}
+
+impl IntoRawFd for EventFd {
+    fn into_raw_fd(self) -> RawFd {
+        self.read_fd.into_raw_fd()
+        // write_fd is dropped here
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Note: the Linux `test_write_overflow` is intentionally not mirrored
+    // here. Linux `eventfd` exposes a `u64` counter whose overflow returns
+    // `EAGAIN` on non-blocking writes; our pipe-backed emulation has no
+    // counter (each `write` appends 8 bytes to a pipe) and also silently
+    // swallows `EAGAIN` when the pipe is full (matching libkrun's
+    // behavior), so the condition that test exercises cannot occur.
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        EventFd::new(EFD_NONBLOCK).unwrap();
+        EventFd::new(0).unwrap();
+    }
+
+    #[test]
+    fn test_read_write() {
+        let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        evt.write(55).unwrap();
+        assert_eq!(evt.read().unwrap(), 55);
+    }
+
+    #[test]
+    fn test_read_nothing() {
+        let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        let err = evt.read().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    fn test_clone() {
+        let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        let evt_clone = evt.try_clone().unwrap();
+        evt.write(923).unwrap();
+        assert_eq!(evt_clone.read().unwrap(), 923);
+    }
+
+    #[test]
+    fn test_cloexec() {
+        let evt = EventFd::new(EFD_CLOEXEC).unwrap();
+        // SAFETY: fd is valid for the lifetime of `evt`.
+        let flags = unsafe { libc::fcntl(evt.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags >= 0);
+        assert_ne!(flags & libc::FD_CLOEXEC, 0);
+    }
+
+    #[test]
+    fn test_into_raw_fd() {
+        let evt = EventFd::new(EFD_NONBLOCK).unwrap();
+        let read_fd = evt.as_raw_fd();
+        let raw = evt.into_raw_fd();
+        assert_eq!(raw, read_fd);
+        // SAFETY: fd is still open (ownership was transferred out of `evt`).
+        unsafe {
+            libc::close(raw);
+        }
+    }
+}

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,0 +1,10 @@
+// Copyright 2024 rust-vmm Authors or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! macOS-specific modules providing compatibility shims for Linux APIs.
+//!
+//! - `eventfd`: Pipe-backed emulation of Linux eventfd.
+//! - `epoll`: kqueue-backed emulation of Linux epoll.
+
+pub mod epoll;
+pub mod eventfd;


### PR DESCRIPTION
### Summary of the PR

Add macOS implementations of the Linux epoll and eventfd APIs so that crates depending on vmm-sys-util (notably vhost-user-backend consumers such as virtiofsd) can compile and run on macOS. epoll is emulated on top of kqueue; eventfd is emulated using a pipe pair.

Both modules are adapted from the libkrun project. The sources were taken from the `main` branch of https://github.com/containers/libkrun as of 2026-04-17 (HEAD a3b7ae213195c9f871a17c72f0d020e46ed90584 at the time of adaptation; most recent change to the copied files: commit 9168b0312bb2fb30b50fcfdb1825958a6a30f338 on 2026-03-07):

- src/macos/epoll.rs   adapted from src/utils/src/macos/epoll.rs
- src/macos/eventfd.rs adapted from src/utils/src/macos/eventfd.rs

The files retain their original copyright notices (Sergio Lopez, 2021; Amazon.com, Inc., 2020) and their original SPDX identifiers:

- epoll.rs:   Apache-2.0
- eventfd.rs: Apache-2.0 AND BSD-3-Clause

The crate's `license` field in Cargo.toml is updated to `BSD-3-Clause AND Apache-2.0` to reflect the mixed licensing, and a new `LICENSE-Apache-2.0` file is added alongside the existing `LICENSE-BSD-3-Clause`.

Local changes relative to the libkrun originals:

- Reshape the public surface to match vmm-sys-util's existing Linux epoll/eventfd API (e.g. `EpollEvent` field visibility, `ctl()` taking `EpollEvent` by value, `wait(timeout, events)` signature without a separate `max_events` argument).
- eventfd: add `EFD_CLOEXEC` support, implement `FromRawFd` and `IntoRawFd`, and switch from `nix` back to raw `libc` to avoid adding a new dependency.
- epoll: add `ONE_SHOT`, `EXCLUSIVE`, `WAKE_UP`, `ERROR` and `PRIORITY` flags, honor the caller-supplied timeout instead of a hardcoded 3-second timespec, drop the `add_oneshot_timer` helper and the `log`-based debug tracing, and return `io::Error` on kevent registration failures instead of asserting.

Credit to Sergio Lopez and the libkrun contributors for the original implementations.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.

### Notes

- **I understand that this PR might be quite controversial and/or problematic.** This takes and adapts the implementation from libkrun. And because of that it requires the licensing changes. If that is not wanted, then somebody needs to write this or something similar from scatch.
- Furthermore, this emulates `epoll` and `eventfd` only because vhost-user-backend requires it. Obviously, it would be nicer if that would not be a requirement there to begin with, but would have a more generic interface.
- This PR is the outcome of a discussion ona virtiofsd issue here: https://gitlab.com/virtio-fs/virtiofsd/-/work_items/169
- I know that [German Maglione](https://gitlab.com/germag) said that he would work on this PR I'm opening here right now this week, but it apparently did not happen, so I decided I make a PR with the patch to this crate that I'm currently using myself for my own private (working) macOS virtiofsd implementation.
- This does not complete full macOS support just yet. While the crate compiles and with these changes the `vhost` and `vhost-user-backend` compile on macOS (and seem to work well for me), there are 4x unit tests (unrelated to the functionality in here) which are currently failing. Might be related to this PR here: https://github.com/rust-vmm/vmm-sys-util/pull/159
- Also, if I understand the CI repository correctly, the unit tests here would not be running on macOS.