### PR TITLE
macos: add signal shim for downstream rust-vmm crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.rs.bk
 Cargo.lock
 
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [[#254](https://github.com/rust-vmm/vmm-sys-util/pull/254)]: Support `TFD_NONBLOCK` for `timerfd::TimerFd`.
+- [[#268](https://github.com/rust-vmm/vmm-sys-util/pull/268)]: Add macOS support for the `signal` module. The shim is gated behind `#[cfg(target_os = "macos")]` and adds no new dependencies; Linux and Android builds are unaffected. macOS consumers needing epoll-shaped polling should use `mio` (see vhost #316). `eventfd` is not provided: the cross-platform `EventConsumer`/`EventNotifier` primitive added in #244 already covers the daemon use case, and `vhost`'s public traits that take `&EventFd` are Linux-only callers (a follow-up gates them on Linux).
 
 ## v0.15.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,11 @@ mod linux;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub use crate::linux::*;
 
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub use crate::macos::*;
+
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2024 rust-vmm Authors. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! macOS-specific modules providing compatibility shims for Linux-only APIs.
+
+pub mod signal;

--- a/src/macos/signal.rs
+++ b/src/macos/signal.rs
@@ -1,0 +1,407 @@
+// Copyright 2024 rust-vmm Authors. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! macOS-compatible signal handling shim.
+//!
+//! Provides the subset of the Linux signal module API needed by downstream crates.
+//! macOS does not have real-time signals or `sigtimedwait`, so those are omitted.
+
+use libc::{
+    c_int, c_void, pthread_kill, pthread_sigmask, pthread_t, sigaction, sigaddset, sigemptyset,
+    sigfillset, siginfo_t, sigismember, sigpending, sigset_t, EINTR, EINVAL, SIG_BLOCK,
+    SIG_UNBLOCK,
+};
+
+use crate::errno;
+use std::fmt::{self, Display};
+use std::io;
+use std::mem;
+use std::os::unix::thread::JoinHandleExt;
+use std::ptr::{null, null_mut};
+use std::result;
+use std::thread::JoinHandle;
+
+/// The error cases enumeration for signal handling.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    /// Couldn't create a sigset.
+    CreateSigset(errno::Error),
+    /// The wrapped signal has already been blocked.
+    SignalAlreadyBlocked(c_int),
+    /// Failed to check if the requested signal is in the blocked set already.
+    CompareBlockedSignals(errno::Error),
+    /// The signal could not be blocked.
+    BlockSignal(errno::Error),
+    /// The signal mask could not be retrieved.
+    RetrieveSignalMask(c_int),
+    /// The signal could not be unblocked.
+    UnblockSignal(errno::Error),
+    /// Failed to wait for given signal.
+    ClearWaitPending(errno::Error),
+    /// Failed to get pending signals.
+    ClearGetPending(errno::Error),
+    /// Failed to check if given signal is in the set of pending signals.
+    ClearCheckPending(errno::Error),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use self::Error::*;
+
+        match self {
+            CreateSigset(e) => write!(f, "couldn't create a sigset: {}", e),
+            SignalAlreadyBlocked(num) => write!(f, "signal {} already blocked", num),
+            CompareBlockedSignals(e) => write!(
+                f,
+                "failed to check whether requested signal is in the blocked set: {}",
+                e,
+            ),
+            BlockSignal(e) => write!(f, "signal could not be blocked: {}", e),
+            RetrieveSignalMask(errno) => write!(
+                f,
+                "failed to retrieve signal mask: {}",
+                io::Error::from_raw_os_error(*errno),
+            ),
+            UnblockSignal(e) => write!(f, "signal could not be unblocked: {}", e),
+            ClearWaitPending(e) => write!(f, "failed to wait for given signal: {}", e),
+            ClearGetPending(e) => write!(f, "failed to get pending signals: {}", e),
+            ClearCheckPending(e) => write!(
+                f,
+                "failed to check whether given signal is in the pending set: {}",
+                e,
+            ),
+        }
+    }
+}
+
+/// A simplified Result type for operations that can return signal Error.
+pub type SignalResult<T> = result::Result<T, Error>;
+
+/// Public alias for a signal handler.
+pub type SignalHandler =
+    extern "C" fn(num: c_int, info: *mut siginfo_t, _unused: *mut c_void) -> ();
+
+/// Verify that a signal number is valid.
+///
+/// macOS does not have real-time signals, so only standard signals (1..=31) are accepted.
+/// Note: macOS signal numbers are not ordered the same as Linux — SIGSYS=12 but SIGUSR2=31.
+pub fn validate_signal_num(num: c_int) -> errno::Result<()> {
+    if (1..=libc::SIGUSR2).contains(&num) {
+        Ok(())
+    } else {
+        Err(errno::Error::new(EINVAL))
+    }
+}
+
+/// Register the signal handler of `signum`.
+///
+/// # Safety
+///
+/// This is considered unsafe because the given handler will be called
+/// asynchronously, interrupting whatever the thread was doing and therefore
+/// must only do async-signal-safe operations.
+pub fn register_signal_handler(num: c_int, handler: SignalHandler) -> errno::Result<()> {
+    validate_signal_num(num)?;
+
+    if libc::SIGKILL == num || libc::SIGSTOP == num {
+        return Err(errno::Error::new(EINVAL));
+    }
+
+    // SAFETY: Safe, because this is a POD struct.
+    let mut act: sigaction = unsafe { mem::zeroed() };
+    act.sa_sigaction = handler as *const () as usize;
+    act.sa_flags = libc::SA_SIGINFO;
+
+    // Block all signals while the `handler` is running.
+    // SAFETY: The parameters are valid and we trust the sigfillset function.
+    if unsafe { sigfillset(&mut act.sa_mask as *mut sigset_t) } < 0 {
+        return errno::errno_result();
+    }
+
+    // SAFETY: Safe because the parameters are valid and we check the return value.
+    match unsafe { sigaction(num, &act, null_mut()) } {
+        0 => Ok(()),
+        _ => errno::errno_result(),
+    }
+}
+
+/// Create a `sigset` with given signals.
+pub fn create_sigset(signals: &[c_int]) -> errno::Result<sigset_t> {
+    // SAFETY: sigset will actually be initialized by sigemptyset below.
+    let mut sigset: sigset_t = unsafe { mem::zeroed() };
+
+    // SAFETY: return value is checked.
+    let ret = unsafe { sigemptyset(&mut sigset) };
+    if ret < 0 {
+        return errno::errno_result();
+    }
+
+    for signal in signals {
+        // SAFETY: return value is checked.
+        let ret = unsafe { sigaddset(&mut sigset, *signal) };
+        if ret < 0 {
+            return errno::errno_result();
+        }
+    }
+
+    Ok(sigset)
+}
+
+/// Retrieve the signal mask that is blocked of the current thread.
+pub fn get_blocked_signals() -> SignalResult<Vec<c_int>> {
+    let mut mask = Vec::new();
+
+    // SAFETY: return values are checked.
+    unsafe {
+        let mut old_sigset: sigset_t = mem::zeroed();
+        let ret = pthread_sigmask(SIG_BLOCK, null(), &mut old_sigset as *mut sigset_t);
+        if ret < 0 {
+            return Err(Error::RetrieveSignalMask(ret));
+        }
+
+        // macOS signals go from 1 to SIGUSR2 (31)
+        for num in 1..=libc::SIGUSR2 {
+            if sigismember(&old_sigset, num) > 0 {
+                mask.push(num);
+            }
+        }
+    }
+
+    Ok(mask)
+}
+
+/// Mask a given signal.
+#[allow(clippy::comparison_chain)]
+pub fn block_signal(num: c_int) -> SignalResult<()> {
+    let sigset = create_sigset(&[num]).map_err(Error::CreateSigset)?;
+
+    // SAFETY: return values are checked.
+    unsafe {
+        let mut old_sigset: sigset_t = mem::zeroed();
+        let ret = pthread_sigmask(SIG_BLOCK, &sigset, &mut old_sigset as *mut sigset_t);
+        if ret < 0 {
+            return Err(Error::BlockSignal(errno::Error::last()));
+        }
+        let ret = sigismember(&old_sigset, num);
+        if ret < 0 {
+            return Err(Error::CompareBlockedSignals(errno::Error::last()));
+        } else if ret > 0 {
+            return Err(Error::SignalAlreadyBlocked(num));
+        }
+    }
+    Ok(())
+}
+
+/// Unmask a given signal.
+pub fn unblock_signal(num: c_int) -> SignalResult<()> {
+    let sigset = create_sigset(&[num]).map_err(Error::CreateSigset)?;
+
+    // SAFETY: return value is checked.
+    let ret = unsafe { pthread_sigmask(SIG_UNBLOCK, &sigset, null_mut()) };
+    if ret < 0 {
+        return Err(Error::UnblockSignal(errno::Error::last()));
+    }
+    Ok(())
+}
+
+/// Clear a pending signal.
+///
+/// On macOS, `sigtimedwait` is not available. This implementation uses
+/// a temporary signal handler to consume the pending signal.
+pub fn clear_signal(num: c_int) -> SignalResult<()> {
+    let sigset = create_sigset(&[num]).map_err(Error::CreateSigset)?;
+
+    // Unblock the signal temporarily to let it be delivered.
+    // SAFETY: sigset was constructed by create_sigset; null oldset is allowed.
+    let _ = unsafe { pthread_sigmask(SIG_UNBLOCK, &sigset, null_mut()) };
+
+    // Re-block it.
+    // SAFETY: same valid sigset; null oldset is allowed.
+    let _ = unsafe { pthread_sigmask(SIG_BLOCK, &sigset, null_mut()) };
+
+    // Check if still pending.
+    // SAFETY: chkset is zeroed (valid empty sigset). sigpending/sigismember
+    // only read or fill the sigset; return values are checked.
+    unsafe {
+        let mut chkset: sigset_t = mem::zeroed();
+        let ret = sigpending(&mut chkset);
+        if ret < 0 {
+            return Err(Error::ClearGetPending(errno::Error::last()));
+        }
+
+        let ret = sigismember(&chkset, num);
+        if ret < 0 {
+            return Err(Error::ClearCheckPending(errno::Error::last()));
+        }
+    }
+
+    Ok(())
+}
+
+/// Trait for threads that can be signalled via `pthread_kill`.
+///
+/// # Safety
+///
+/// This is marked unsafe because the implementation of this trait must
+/// guarantee that the returned `pthread_t` is valid and has a lifetime at
+/// least that of the trait object.
+pub unsafe trait Killable {
+    /// Cast this killable thread as `pthread_t`.
+    fn pthread_handle(&self) -> pthread_t;
+
+    /// Send a signal to this killable thread.
+    fn kill(&self, num: c_int) -> errno::Result<()> {
+        validate_signal_num(num)?;
+
+        // SAFETY: Safe because we ensure we are using a valid pthread handle,
+        // a valid signal number, and check the return result.
+        let ret = unsafe { pthread_kill(self.pthread_handle(), num) };
+        if ret < 0 {
+            return errno::errno_result();
+        }
+        Ok(())
+    }
+}
+
+// SAFETY: Safe because we fulfill our contract of returning a genuine pthread handle.
+unsafe impl<T> Killable for JoinHandle<T> {
+    fn pthread_handle(&self) -> pthread_t {
+        self.as_pthread_t() as pthread_t
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    // Set by handle_signal; checked by tests.
+    static mut SIGNAL_HANDLER_CALLED: bool = false;
+
+    extern "C" fn handle_signal(_: c_int, _: *mut siginfo_t, _: *mut c_void) {
+        unsafe {
+            SIGNAL_HANDLER_CALLED = true;
+        }
+    }
+
+    fn is_pending(signal: c_int) -> bool {
+        unsafe {
+            let mut chkset: sigset_t = mem::zeroed();
+            sigpending(&mut chkset);
+            sigismember(&chkset, signal) == 1
+        }
+    }
+
+    #[test]
+    fn test_validate_signal_num() {
+        // macOS signals: 1..=SIGUSR2 (=31). Anything outside this is EINVAL.
+        // SIGHUP=1 is the lowest valid, SIGUSR2=31 is the highest. Linux's
+        // SIGHUP..=SIGSYS range would reject SIGUSR2 here (SIGSYS=12 on
+        // macOS), which is the original bug this validator works around.
+        assert!(validate_signal_num(1).is_ok());
+        assert!(validate_signal_num(libc::SIGUSR2).is_ok());
+        assert!(validate_signal_num(libc::SIGSYS).is_ok());
+        assert!(validate_signal_num(libc::SIGTERM).is_ok());
+
+        assert!(validate_signal_num(0).is_err());
+        assert!(validate_signal_num(libc::SIGUSR2 + 1).is_err());
+        assert!(validate_signal_num(-1).is_err());
+    }
+
+    #[test]
+    fn test_register_signal_handler() {
+        // SIGKILL / SIGSTOP must be rejected, valid signals must succeed.
+        assert!(register_signal_handler(libc::SIGKILL, handle_signal).is_err());
+        assert!(register_signal_handler(libc::SIGSTOP, handle_signal).is_err());
+        assert!(register_signal_handler(libc::SIGUSR2 + 1, handle_signal).is_err());
+        assert!(register_signal_handler(libc::SIGUSR1, handle_signal).is_ok());
+        assert!(register_signal_handler(libc::SIGUSR2, handle_signal).is_ok());
+        assert!(register_signal_handler(libc::SIGSYS, handle_signal).is_ok());
+    }
+
+    #[test]
+    fn test_block_unblock_signal() {
+        // SIGUSR2 is used here precisely because its macOS signal number (31)
+        // is what the Linux SIGHUP..=SIGSYS range rejected. Picking it pins
+        // the validator fix as well as the block/unblock round-trip.
+        let signal = libc::SIGUSR2;
+
+        unsafe {
+            let mut sigset: sigset_t = mem::zeroed();
+            pthread_sigmask(SIG_BLOCK, null(), &mut sigset as *mut sigset_t);
+            assert_eq!(sigismember(&sigset, signal), 0);
+        }
+
+        block_signal(signal).unwrap();
+        assert!(get_blocked_signals().unwrap().contains(&signal));
+
+        unblock_signal(signal).unwrap();
+        assert!(!get_blocked_signals().unwrap().contains(&signal));
+    }
+
+    #[test]
+    #[allow(clippy::empty_loop)]
+    fn test_killing_thread() {
+        // Mirror of the Linux test, adapted for macOS signal numbering.
+        // macOS has no real-time signals; SIGUSR1 is the conventional
+        // user-defined signal safe to register and deliver in tests.
+        let killable = thread::spawn(|| thread::current().id());
+        let killable_id = killable.join().unwrap();
+        assert_ne!(killable_id, thread::current().id());
+
+        // Handler is process-global, so install before spawning the
+        // long-lived thread.
+        register_signal_handler(libc::SIGUSR1, handle_signal)
+            .expect("failed to register signal handler");
+
+        let killable = thread::spawn(|| loop {});
+
+        // Out-of-range signal must fail.
+        assert!(killable.kill(libc::SIGUSR2 + 1).is_err());
+
+        unsafe {
+            assert!(!SIGNAL_HANDLER_CALLED);
+        }
+
+        assert!(killable.kill(libc::SIGUSR1).is_ok());
+
+        const MAX_WAIT_ITERS: u32 = 20;
+        let mut iter_count = 0;
+        loop {
+            thread::sleep(Duration::from_millis(100));
+            if unsafe { SIGNAL_HANDLER_CALLED } {
+                break;
+            }
+            iter_count += 1;
+            assert!(iter_count <= MAX_WAIT_ITERS);
+        }
+
+        // killable runs an infinite loop; intentionally do not join it.
+        // It becomes detached when the JoinHandle is dropped and dies
+        // with the process.
+    }
+
+    #[test]
+    fn test_clear_pending() {
+        // Block SIGUSR2, queue it, then clear it. Pins that clear_signal
+        // removes the pending bit on macOS (which has no sigtimedwait, so
+        // the implementation unblocks/reblocks instead).
+        let signal = libc::SIGUSR2;
+
+        block_signal(signal).unwrap();
+
+        let killable = thread::spawn(move || loop {
+            thread::sleep(Duration::from_millis(100));
+            if is_pending(signal) {
+                clear_signal(signal).unwrap();
+                assert!(!is_pending(signal));
+                break;
+            }
+        });
+
+        assert!(killable.kill(libc::SIGUSR2).is_ok());
+        killable.join().unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

Adds macOS support for the `signal` module so downstream rust-vmm crates can install process-lifecycle signal handlers (`register_signal_handler`, `block_signal`, `Killable`, etc.) on macOS the same way they do on Linux today. All macOS code is gated behind `#[cfg(target_os = "macos")]` and adds no new dependencies; Linux and Android builds are unaffected. The crate stays at `BSD-3-Clause` and no third-party code is vendored — everything in this PR is original work.

## Why this is needed

vmm-sys-util already provides a Linux `signal` module that wraps the POSIX `sigaction`/`sigprocmask`/`sigpending` machinery and exposes typed helpers used across the rust-vmm ecosystem. Without an equivalent on macOS, any consumer that uses those helpers fails to compile on macOS — there is no `vmm_sys_util::signal::*` for the `cfg` resolver to find.

Concrete real-world consumer: virtiofsd installs a clean-exit handler for `SIGHUP` and `SIGTERM` so the process tears down its vhost-user socket cleanly when the controlling terminal closes or systemd stops it:

```rust
// virtiofsd src/main.rs
fn set_signal_handlers() {
    use vmm_sys_util::signal;
    extern "C" fn handle_signal(_: c_int, _: *mut siginfo_t, _: *mut c_void) {
        unsafe { libc::_exit(1) };
    }
    for s in [libc::SIGHUP, libc::SIGTERM] {
        signal::register_signal_handler(s, handle_signal)?;
    }
}
```

The wrapper isn't doing anything magical — it could be written against raw `libc::sigaction` — but using `vmm_sys_util::signal` here gets the same validation (`validate_signal_num`), the same error-handling shape, and the same `Killable` abstraction that the rest of the rust-vmm ecosystem uses. Having one consistent API makes consumers portable across platforms with no `#[cfg]` at the call site.

## Why this code lives in vmm-sys-util

Symmetric placement: the Linux signal module already lives in vmm-sys-util as `src/linux/signal.rs`. Putting the macOS equivalent under `src/macos/signal.rs` keeps "POSIX signal helpers for rust-vmm" in one crate instead of splitting it across crates by platform. Anyone who later wants to bring another rust-vmm crate to macOS gets the same API for free.

The shim is also self-contained: ~400 lines, its own unit tests, no new dependencies on the crate. Linux/Android builds don't see it at all.

(If maintainers would prefer to keep vmm-sys-util Linux-only and push macOS shims into the downstream consumers that need them, that's also reasonable and I'm happy to take the code elsewhere. Wanted to flag the option.)

## What's in it

- **`src/macos/signal.rs`** — POSIX signal helpers mirroring the Linux module's public API.
  - Host-signal validation uses `1..=SIGUSR2` because macOS signal numbers do not match Linux's (`SIGSYS=12`, `SIGTERM=15`, `SIGUSR2=31`). The `SIGHUP..=SIGSYS` range used on Linux would reject valid macOS signals.
  - Pending-signal clearing goes via unblock-then-reblock because macOS does not expose `sigtimedwait`.

## What's *not* in it (and why)

This PR deliberately omits `eventfd` and `epoll` shims that an earlier draft of this branch included, after upstream discussion on #266.

- **No `eventfd` shim.** The cross-platform `EventConsumer` / `EventNotifier` primitive added in #244 already covers the daemon side of `vhost-user-backend`. The remaining macOS callers of `vmm_sys_util::eventfd::EventFd` are inside the `vhost` crate's `VhostBackend` / `VhostBackendMut` traits, whose only consumers are Linux-only (kernel vhost drivers, vhost-user frontends inside Linux-only VMMs). A small follow-up PR to `vhost` gates those trait methods on `#[cfg(target_os = \"linux\")]`, after which nothing in the macOS build path references `vmm_sys_util::eventfd` and a shim is genuinely unnecessary.

- **No `epoll` shim.** Consumers needing epoll-shaped polling on macOS should use `mio` (see rust-vmm/vhost#316), which gives proper cross-platform event polling backed by `kqueue` on macOS — a cleaner architectural answer than shimming the Linux API.

The previous version of this branch carried both shims, adapted from libkrun, which required dual-licensing the crate as `BSD-3-Clause AND Apache-2.0`. Dropping those shims removes the libkrun derivation entirely; the crate stays single-licensed `BSD-3-Clause`.

## End-to-end validation

The signal-only version of this PR + rust-vmm/vhost#316 (mio rewrite) + the `VhostBackend` cfg-gating follow-up was tested on `aarch64-apple-darwin`: virtiofsd → `vhost-user-backend` → `vhost` → `vmm-sys-util` builds clean and 75/75 virtiofsd lib tests pass.

## Tests

- `macos::signal::tests` — validator range, register/block/unblock/kill round-trips, pending-signal clearing.

There are 4 pre-existing test failures in `rand` and `unix::tempdir` on macOS that this PR does not introduce or fix; they are out of scope.

## Checklist

- [x] All commits in this PR have \`Signed-off-by\` trailers, subject ≤ 60 chars and body lines ≤ 75 chars.
- [x] All added/changed functionality has a corresponding unit test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming Release" section of `CHANGELOG.md`.
- [x] Any newly added `unsafe` code is properly documented.